### PR TITLE
Carrier metadata update for HR - 385 (en)

### DIFF
--- a/resources/carrier/en/385.txt
+++ b/resources/carrier/en/385.txt
@@ -12,11 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# 385 - Croatia
+
+# Source(s):
+# -----------------------
+# HAKOM: https://www.hakom.hr/default.aspx?id=817
+# -----------------------
+
+# Carriers:
+# -----------------------
+# Hrvatski Telekom: hrvatskitelekom.hr - Hrvatski Telekom d.d.
+# Vip: vipnet.hr - VIPnet d.o.o.
+# Tele2: tele2.hr - Tele2 d.o.o.
+# bonbon: bonbon.hr - Hrvatski Telekom d.d.
+# Telefocus: telefocus.hr - TELEFOCUS d.o.o.
+# -----------------------
+
+# -----------------------
+# Last checked: 6/12/2017
+# Last updated: 6/12/2017
+# -----------------------
+
 38591|Vip
 38592|Vip
 38595|Tele2
-385976|Bonbon
-385977|Bonbon
-385979|MultiPlus
-38598|T-Mobile
-38599|T-Mobile
+385970|Hrvatski Telekom
+3859751|Telefocus
+385976|bonbon
+385977|bonbon
+385979|Hrvatski Telekom
+38598|Hrvatski Telekom
+38599|Hrvatski Telekom


### PR DESCRIPTION
- **T-Mobile** is not used as a brand anymore on many of Deutsche Telekom subsidiaries; in Croatia they operate under **Hrvatski Telekom** brand:
  1. https://en.wikipedia.org/wiki/T-Mobile
  2. http://hrvatskitelekom.hr
- **Multiplus** no longer operational: 
http://www.mobil.hr/operateri/multiplus-mobile-mreza-prestaje-s-radom/