### PR TITLE
Add Russian preferredExtnPrefix

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -22728,7 +22728,7 @@
     <!-- Main region for 'KZ' -->
     <territory id="RU" mainCountryForCode="true" countryCode="7" preferredInternationalPrefix="8~10"
                internationalPrefix="810" nationalPrefix="8" nationalPrefixFormattingRule="$NP ($FG)"
-               nationalPrefixOptionalWhenFormatting="true">
+               nationalPrefixOptionalWhenFormatting="true" preferredExtnPrefix=", доб. ">
       <references>
         <sourceUrl>http://www.itu.int/oth/T02020000AD/en</sourceUrl>
         <sourceUrl>http://en.wikipedia.org/wiki/%2B7</sourceUrl>


### PR DESCRIPTION
In Russia we use ", доб. " (meaning "добавочный") as an extension prefix instead of " ext. ".

Proof:

http://programmes.putin.kremlin.ru/amur_leopard/news/24580
(scroll down to bottom of page content: "8 (423) 202-25-11, доб. 100 (отдел науки и экологического просвещения)")

http://static.kremlin.ru/media/events/files/ru/tlDwxhOd8pd2BaAjWsNRkCQR7rQYxLIy.pdf
(page 18: "тел.: +7 (495) 988-53-88, доб. 1311")