### PR TITLE
Made animal sniffer maven plugin version declared in one place

### DIFF
--- a/java/carrier/pom.xml
+++ b/java/carrier/pom.xml
@@ -32,7 +32,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.15</version>
         <executions>
           <execution>
             <phase>test</phase>

--- a/java/geocoder/pom.xml
+++ b/java/geocoder/pom.xml
@@ -40,7 +40,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.15</version>
         <executions>
           <execution>
             <phase>test</phase>

--- a/java/internal/prefixmapper/pom.xml
+++ b/java/internal/prefixmapper/pom.xml
@@ -27,7 +27,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.15</version>
         <executions>
           <execution>
             <phase>test</phase>

--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -72,7 +72,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.15</version>
         <executions>
           <execution>
             <phase>test</phase>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -103,6 +103,11 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>animal-sniffer-maven-plugin</artifactId>
+          <version>1.17</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -106,7 +106,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>1.17</version>
+          <version>1.15</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Removing configuration of animal sniffer's maven pulgin version number at component level.
Note:
- This is being done to make sure the setup is clean to a working state, and avoid issues reported in #2356.
- The plugin version number is now mentioned at parent level java/libphonenumber/pom.xml