### PR TITLE
Add new build options

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -86,6 +86,7 @@ option ("USE_LITE_METADATA" "Use lite metadata" "OFF")
 option ("USE_RE2" "Use RE2" "OFF")
 option ("USE_STD_MAP" "Force the use of std::map" "OFF")
 option ("BUILD_STATIC_LIB" "Build static libraries" "ON")
+option ("USE_PROTOBUF_LITE" "Link to protobuf-lite" "OFF")
 
 if (${USE_ALTERNATE_FORMATS} STREQUAL "ON")
   add_definitions ("-DI18N_PHONENUMBERS_USE_ALTERNATE_FORMATS")
@@ -110,9 +111,15 @@ if (${USE_RE2} STREQUAL "ON")
   find_required_library (RE2 re2/re2.h re2 "Google RE2")
 endif ()
 
-find_required_library (PROTOBUF google/protobuf/message_lite.h protobuf
-                       "Google Protocol Buffers")
-check_library_version (PC_PROTOBUF protobuf>=2.4)
+if (${USE_PROTOBUF_LITE} STREQUAL "ON")
+  find_required_library (PROTOBUF google/protobuf/message_lite.h protobuf-lite
+                         "Google Protocol Buffers")
+  check_library_version (PC_PROTOBUF protobuf-lite>=2.4)
+else ()
+  find_required_library (PROTOBUF google/protobuf/message_lite.h protobuf
+                         "Google Protocol Buffers")
+  check_library_version (PC_PROTOBUF protobuf>=2.4)
+endif ()
 
 find_required_library (ICU_UC unicode/uchar.h icuuc "ICU")
 check_library_version (PC_ICU_UC icu-uc>=4.4)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -87,6 +87,7 @@ option ("USE_RE2" "Use RE2" "OFF")
 option ("USE_STD_MAP" "Force the use of std::map" "OFF")
 option ("BUILD_STATIC_LIB" "Build static libraries" "ON")
 option ("USE_PROTOBUF_LITE" "Link to protobuf-lite" "OFF")
+option ("REGENERATE_METADATA" "Regenerate metadata instead of using it from the source tree" "ON")
 
 if (${USE_ALTERNATE_FORMATS} STREQUAL "ON")
   add_definitions ("-DI18N_PHONENUMBERS_USE_ALTERNATE_FORMATS")
@@ -137,8 +138,10 @@ endif ()
 find_required_program (PROTOC protoc
                        "Google Protocol Buffers compiler (protoc)")
 
-find_required_program (JAVA java
-                       "Java Runtime Environment")
+if (${REGENERATE_METADATA} STREQUAL "ON")
+  find_required_program (JAVA java
+                         "Java Runtime Environment")
+endif ()
 
 if (APPLE)
   FIND_LIBRARY (COREFOUNDATION_LIB CoreFoundation)
@@ -278,14 +281,26 @@ function (add_metadata_gen_target TARGET_NAME
   set (JAR_PATH "${CMAKE_SOURCE_DIR}/../tools/java/cpp-build/target")
   set (JAR_PATH "${JAR_PATH}/cpp-build-1.0-SNAPSHOT-jar-with-dependencies.jar")
 
-  add_custom_command (
-    COMMAND ${JAVA_BIN} -jar
-      ${JAR_PATH} BuildMetadataCppFromXml ${XML_FILE}
-      ${CMAKE_SOURCE_DIR}/src/phonenumbers ${METADATA_TYPE}
+  if (${REGENERATE_METADATA} STREQUAL "ON")
+    add_custom_command (
+      COMMAND ${JAVA_BIN} -jar
+        ${JAR_PATH} BuildMetadataCppFromXml ${XML_FILE}
+        ${CMAKE_SOURCE_DIR}/src/phonenumbers ${METADATA_TYPE}
 
-    OUTPUT ${GEN_OUTPUT}
-    DEPENDS ${XML_FILE}
-  )
+      OUTPUT ${GEN_OUTPUT}
+      DEPENDS ${XML_FILE}
+    )
+  else ()
+    add_custom_command (
+      COMMAND echo "skip metadata generation from"
+        ${XML_FILE} "to"
+        ${CMAKE_SOURCE_DIR}/src/phonenumbers ${METADATA_TYPE}
+
+      OUTPUT ${GEN_OUTPUT}
+      DEPENDS ${XML_FILE}
+    )
+  endif ()
+  
   add_custom_target (
     ${TARGET_NAME}
     DEPENDS ${GEN_OUTPUT}


### PR DESCRIPTION
This pull request adds two new build options:

* `USE_PROTOBUF_LITE` - When this is set to `ON` then it links against `protobuf-lite` instead of the full version of `protobuf`. As far as I could see the metadata has `option optimize_for = LITE_RUNTIME;` so it should be safe to use the lite version. This is useful when you want to save some disk space. The default is `OFF`.
* `REGENERATE_METADATA` - When this is set to `OFF` it will skip regenerating the metadata with `BuildMetadataCppFromXml`. Since the metadata is included in the source tree anyway, it is beneficial for packagers to turn this `OFF`: it saves some time, and it also makes it unnecessary to have java in the build environment. The default is `ON`.

Please let me know what you guys think.