### PR TITLE
cpp/CMakeLists.txt: Fix find_required_program check for -NOTFOUND

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -72,7 +72,7 @@ endfunction ()
 function (find_required_program NAME FILENAME DESCRIPTION)
   find_program (${NAME}_BIN NAMES ${FILENAME})
 
-  if (${NAME}_BIN STREQUAL "${${NAME}_BIN}-NOTFOUND")
+  if (${NAME}_BIN STREQUAL "${NAME}_BIN-NOTFOUND")
     print_error (${DESCRIPTION} ${FILENAME})
   endif ()
 endfunction (find_required_program)


### PR DESCRIPTION
Currently the find_required_program function checks for
"${${NAME}_BIN}-NOTFOUND" which has an extra level of indirection
causing the function to miss when a program isn't found:

[1/127] Generating src/phonenumbers/metadata.cc, src/phonenumbers/metadata.h
FAILED: src/phonenumbers/metadata.cc src/phonenumbers/metadata.h
cd /run/build/libphonenumber/cpp && JAVA_BIN-NOTFOUND -jar /run/build/libphonenumber/cpp/../tools/java/cpp-build/target/cpp-build-1.0-SNAPSHOT-jar-with-dependencies.jar BuildMetadataCppFromXml /run/build/libphonenumber/cpp/../resources/PhoneNumberMetadata.xml /run/build/libphonenumber/cpp/src/phonenumbers metadata
/bin/sh: JAVA_BIN-NOTFOUND: command not found

To fix this, we change the function to check for
"${NAME}_BIN-NOTFOUND" instead, which works.