### PR TITLE
Abolish MX's international mobile token (1)

### DIFF
--- a/cpp/src/phonenumbers/asyoutypeformatter.cc
+++ b/cpp/src/phonenumbers/asyoutypeformatter.cc
@@ -479,8 +479,24 @@ void AsYouTypeFormatter::AttemptToFormatAccruedDigits(
       DCHECK(status);
       IGNORE_UNUSED(status);
 
-      AppendNationalNumber(formatted_number, formatted_result);
-      return;
+      string full_output(*formatted_result);
+      // Check that we didn't remove nor add any extra digits when we matched
+      // this formatting pattern. This usually happens after we entered the last
+      // digit during AYTF. Eg: In case of MX, we swallow mobile token (1) when
+      // formatted but AYTF should retain all the number entered and not change
+      // in order to match a format (of same leading digits and length) display
+      // in that way.
+      AppendNationalNumber(formatted_number, &full_output);
+      phone_util_.NormalizeDiallableCharsOnly(&full_output);
+      string accrued_input_without_formatting_stdstring;
+      accrued_input_without_formatting_.toUTF8String(
+          accrued_input_without_formatting_stdstring);
+      if (full_output == accrued_input_without_formatting_stdstring) {
+        // If it's the same (i.e entered number and format is same), then it's
+        // safe to return this in formatted number as nothing is lost / added.
+        AppendNationalNumber(formatted_number, formatted_result);
+        return;
+      }
     }
   }
 }

--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -536,7 +536,6 @@ class PhoneNumberRegExpsAndMappings {
       all_plus_number_grouping_symbols_.insert(std::make_pair(c, c));
     }
 
-    mobile_token_mappings_.insert(std::make_pair(52, '1'));
     mobile_token_mappings_.insert(std::make_pair(54, '9'));
     geo_mobile_countries_without_mobile_area_codes_.insert(86);  // China
     geo_mobile_countries_.insert(52);  // Mexico

--- a/cpp/test/phonenumbers/phonenumberutil_test.cc
+++ b/cpp/test/phonenumbers/phonenumberutil_test.cc
@@ -1541,9 +1541,9 @@ TEST_F(PhoneNumberUtilTest, GetCountryMobileToken) {
   int country_calling_code;
   string mobile_token;
 
-  country_calling_code = phone_util_.GetCountryCodeForRegion(RegionCode::MX());
+  country_calling_code = phone_util_.GetCountryCodeForRegion(RegionCode::AR());
   phone_util_.GetCountryMobileToken(country_calling_code, &mobile_token);
-  EXPECT_EQ("1", mobile_token);
+  EXPECT_EQ("9", mobile_token);
 
   // Country calling code for Sweden, which has no mobile token.
   country_calling_code = phone_util_.GetCountryCodeForRegion(RegionCode::SE());

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java
@@ -426,7 +426,7 @@ public class AsYouTypeFormatter {
             NATIONAL_PREFIX_SEPARATORS_PATTERN.matcher(
                 numberFormat.getNationalPrefixFormattingRule()).find();
         String formattedNumber = m.replaceAll(numberFormat.getFormat());
-        // Check that we didn't remove nor add any extra digits when we matched
+        // Check that we did not remove nor add any extra digits when we matched
         // this formatting pattern. This usually happens after we entered the last
         // digit during AYTF. Eg: In case of MX, we swallow mobile token (1) when
         // formatted but AYTF should retain all the number entered and not change

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java
@@ -426,7 +426,19 @@ public class AsYouTypeFormatter {
             NATIONAL_PREFIX_SEPARATORS_PATTERN.matcher(
                 numberFormat.getNationalPrefixFormattingRule()).find();
         String formattedNumber = m.replaceAll(numberFormat.getFormat());
-        return appendNationalNumber(formattedNumber);
+        // Check that we didn't remove nor add any extra digits when we matched
+        // this formatting pattern. This usually happens after we entered the last
+        // digit during AYTF. Eg: In case of MX, we swallow mobile token (1) when
+        // formatted but AYTF should retain all the number entered and not change
+        // in order to match a format (of same leading digits and length) display
+        // in that way.
+        String fullOutput = appendNationalNumber(formattedNumber);
+        String formattedNumberDigitsOnly = PhoneNumberUtil.normalizeDiallableCharsOnly(fullOutput);
+        if (formattedNumberDigitsOnly.contentEquals(accruedInputWithoutFormatting)) {
+          // If it's the same (i.e entered number and format is same), then it's
+          // safe to return this in formatted number as nothing is lost / added.
+          return fullOutput;
+        }
       }
     }
     return "";

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -122,7 +122,6 @@ public class PhoneNumberUtil {
 
   static {
     HashMap<Integer, String> mobileTokenMap = new HashMap<Integer, String>();
-    mobileTokenMap.put(52, "1");
     mobileTokenMap.put(54, "9");
     MOBILE_TOKEN_MAPPINGS = Collections.unmodifiableMap(mobileTokenMap);
 

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
@@ -352,8 +352,8 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
   }
 
   public void testGetCountryMobileToken() {
-    assertEquals("1", PhoneNumberUtil.getCountryMobileToken(phoneUtil.getCountryCodeForRegion(
-        RegionCode.MX)));
+    assertEquals("9", PhoneNumberUtil.getCountryMobileToken(phoneUtil.getCountryCodeForRegion(
+        RegionCode.AR)));
 
     // Country calling code for Sweden, which has no mobile token.
     assertEquals("", PhoneNumberUtil.getCountryMobileToken(phoneUtil.getCountryCodeForRegion(
@@ -1804,26 +1804,26 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
 
   public void testExtractPossibleNumber() {
     // Removes preceding funky punctuation and letters but leaves the rest untouched.
-    assertEquals("0800-345-600", PhoneNumberUtil.extractPossibleNumber("Tel:0800-345-600"));
-    assertEquals("0800 FOR PIZZA", PhoneNumberUtil.extractPossibleNumber("Tel:0800 FOR PIZZA"));
+    assertEquals("0800-345-600", PhoneNumberUtil.extractPossibleNumber("Tel:0800-345-600").toString());
+    assertEquals("0800 FOR PIZZA", PhoneNumberUtil.extractPossibleNumber("Tel:0800 FOR PIZZA").toString());
     // Should not remove plus sign
-    assertEquals("+800-345-600", PhoneNumberUtil.extractPossibleNumber("Tel:+800-345-600"));
+    assertEquals("+800-345-600", PhoneNumberUtil.extractPossibleNumber("Tel:+800-345-600").toString());
     // Should recognise wide digits as possible start values.
     assertEquals("\uFF10\uFF12\uFF13",
-                 PhoneNumberUtil.extractPossibleNumber("\uFF10\uFF12\uFF13"));
+                 PhoneNumberUtil.extractPossibleNumber("\uFF10\uFF12\uFF13").toString());
     // Dashes are not possible start values and should be removed.
     assertEquals("\uFF11\uFF12\uFF13",
-                 PhoneNumberUtil.extractPossibleNumber("Num-\uFF11\uFF12\uFF13"));
+                 PhoneNumberUtil.extractPossibleNumber("Num-\uFF11\uFF12\uFF13").toString());
     // If not possible number present, return empty string.
-    assertEquals("", PhoneNumberUtil.extractPossibleNumber("Num-...."));
+    assertEquals("", PhoneNumberUtil.extractPossibleNumber("Num-....").toString());
     // Leading brackets are stripped - these are not used when parsing.
-    assertEquals("650) 253-0000", PhoneNumberUtil.extractPossibleNumber("(650) 253-0000"));
+    assertEquals("650) 253-0000", PhoneNumberUtil.extractPossibleNumber("(650) 253-0000").toString());
 
     // Trailing non-alpha-numeric characters should be removed.
-    assertEquals("650) 253-0000", PhoneNumberUtil.extractPossibleNumber("(650) 253-0000..- .."));
-    assertEquals("650) 253-0000", PhoneNumberUtil.extractPossibleNumber("(650) 253-0000."));
+    assertEquals("650) 253-0000", PhoneNumberUtil.extractPossibleNumber("(650) 253-0000..- ..").toString());
+    assertEquals("650) 253-0000", PhoneNumberUtil.extractPossibleNumber("(650) 253-0000.").toString());
     // This case has a trailing RTL char.
-    assertEquals("650) 253-0000", PhoneNumberUtil.extractPossibleNumber("(650) 253-0000\u200F"));
+    assertEquals("650) 253-0000", PhoneNumberUtil.extractPossibleNumber("(650) 253-0000\u200F").toString());
   }
 
   public void testMaybeStripNationalPrefix() {

--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -167,7 +167,6 @@ i18n.phonenumbers.PhoneNumberUtil.COLOMBIA_MOBILE_TO_FIXED_LINE_PREFIX_ = '3';
  * @private
  */
 i18n.phonenumbers.PhoneNumberUtil.MOBILE_TOKEN_MAPPINGS_ = {
-  52: '1',
   54: '9'
 };
 

--- a/javascript/i18n/phonenumbers/phonenumberutil_test.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil_test.js
@@ -424,8 +424,8 @@ function testGetLengthOfNationalDestinationCode() {
 }
 
 function testGetCountryMobileToken() {
-  assertEquals('1', i18n.phonenumbers.PhoneNumberUtil.getCountryMobileToken(
-      phoneUtil.getCountryCodeForRegion(RegionCode.MX)));
+  assertEquals('9', i18n.phonenumbers.PhoneNumberUtil.getCountryMobileToken(
+      phoneUtil.getCountryCodeForRegion(RegionCode.AR)));
 
   // Country calling code for Sweden, which has no mobile token.
   assertEquals('', i18n.phonenumbers.PhoneNumberUtil.getCountryMobileToken(


### PR DESCRIPTION
Remove MX's mobile token value (1) from mobileTokenMap list in PhoneNumberUtil.
Update AYTF to not swallow input numbers like mobile token (1), which we are trimming of when asked to format, as AYTF should represent exact input digits. (This API is only in Java and CPP)

MX's mobile token value (1) has been abolished as part of dialling pattern updates in MX, during Aug 2019. https://www.itu.int/dms_pub/itu-t/oth/02/02/T020200008A0003PDFE.pdf
More details in cl/261295217 and cl/263086682

Notes: 
- Still using HashMap, not ImmutableMap.of() as it needs java 8 and to be consistent with other part of the existing code.
- This PR will be merged on after success completion of migration.
- Will update formatForMobileDialling() for MX case (api that returns most successful format of dialling phonenumbers from mobile), where presently it returns E.64 format for MX and for other regions national format. After this migration national format should hold good enough (previously it failed in some cases based on test results) for mobile dialling within the region.