### PR TITLE
Adding support for metadata proto output to .pb file

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -84,6 +84,7 @@ option ("USE_BOOST" "Use Boost" "ON")
 option ("USE_ICU_REGEXP" "Use ICU regexp engine" "ON")
 option ("USE_LITE_METADATA" "Use lite metadata" "OFF")
 option ("USE_RE2" "Use RE2" "OFF")
+option ("CREATE_PB_FILES" "Create .pb binary metadata files" "OFF")
 option ("USE_STD_MAP" "Force the use of std::map" "OFF")
 option ("BUILD_STATIC_LIB" "Build static libraries" "ON")
 
@@ -268,14 +269,16 @@ function (add_metadata_gen_target TARGET_NAME
   set (METADATA_SOURCE_DIR "${CMAKE_SOURCE_DIR}/src/phonenumbers")
   set (GEN_OUTPUT "${METADATA_SOURCE_DIR}/${METADATA_TYPE}.cc"
                   "${METADATA_SOURCE_DIR}/${METADATA_HEADER}.h")
+  if(CREATE_PB_FILES STREQUAL "ON")
+    list(APPEND GEN_OUTPUT "${METADATA_SOURCE_DIR}/${METADATA_TYPE}.pb")
+  endif()
   set (JAR_PATH "${CMAKE_SOURCE_DIR}/../tools/java/cpp-build/target")
   set (JAR_PATH "${JAR_PATH}/cpp-build-1.0-SNAPSHOT-jar-with-dependencies.jar")
 
   add_custom_command (
     COMMAND ${JAVA_BIN} -jar
       ${JAR_PATH} BuildMetadataCppFromXml ${XML_FILE}
-      ${CMAKE_SOURCE_DIR}/src/phonenumbers ${METADATA_TYPE}
-
+      ${CMAKE_SOURCE_DIR}/src/phonenumbers ${METADATA_TYPE} ${CREATE_PB_FILES}
     OUTPUT ${GEN_OUTPUT}
     DEPENDS ${XML_FILE}
   )

--- a/tools/java/cpp-build/src/com/google/i18n/phonenumbers/BuildMetadataCppFromXml.java
+++ b/tools/java/cpp-build/src/com/google/i18n/phonenumbers/BuildMetadataCppFromXml.java
@@ -95,21 +95,23 @@ public class BuildMetadataCppFromXml extends Command {
         Pattern.compile("(?:(test|lite)_)?([a-z_]+)");
 
     public static Options parse(String commandName, String[] args) {
-      if (args.length == 4) {
+      if (args.length == 5) {
         String inputXmlFilePath = args[1];
         String outputDirPath = args[2];
         Matcher basenameMatcher = BASENAME_PATTERN.matcher(args[3]);
+        boolean createPbFiles = args[4].equals("ON") ? true : false;
         if (basenameMatcher.matches()) {
           Variant variant = Variant.parse(basenameMatcher.group(1));
           Type type = Type.parse(basenameMatcher.group(2));
           if (type != null && variant != null) {
-            return new Options(inputXmlFilePath, outputDirPath, type, variant);
+            return new Options(inputXmlFilePath, outputDirPath, type, variant, createPbFiles);
           }
         }
       }
       throw new IllegalArgumentException(String.format(
-          "Usage: %s <inputXmlFile> <outputDir> ( <type> | test_<type> | lite_<type> )\n" +
-          "       where <type> is one of: %s",
+          "Usage: %s <inputXmlFile> <outputDir> ( <type> | test_<type> | lite_<type> ) <createPbFiles>\n" +
+          "       where <type> is one of: %s\n" +
+          "       where <createPbFiles> when set to true outputs metadata bytes into a .pb file as well.",
           commandName, Arrays.asList(Type.values())));
     }
 
@@ -119,12 +121,14 @@ public class BuildMetadataCppFromXml extends Command {
     private final String outputDirPath;
     private final Type type;
     private final Variant variant;
+    private final boolean createPbFiles;
 
-    private Options(String inputXmlFilePath, String outputDirPath, Type type, Variant variant) {
+    private Options(String inputXmlFilePath, String outputDirPath, Type type, Variant variant, Boolean createPbFiles) {
       this.inputXmlFilePath = inputXmlFilePath;
       this.outputDirPath = outputDirPath;
       this.type = type;
       this.variant = variant;
+      this.createPbFiles = createPbFiles;
     }
 
     public String getInputFilePath() {
@@ -142,6 +146,10 @@ public class BuildMetadataCppFromXml extends Command {
     public Variant getVariant() {
       return variant;
     }
+
+    public Boolean getCreatePbFiles() {
+      return createPbFiles;
+    }
   }
 
   @Override
@@ -152,7 +160,8 @@ public class BuildMetadataCppFromXml extends Command {
   /**
    * Generates C++ header and source files to represent the metadata specified by this command's
    * arguments. The metadata XML file is read and converted to a byte array before being written
-   * into a C++ source file as a static data array.
+   * into a C++ source file as a static data array. If CreatePbFiles is set, the converted bytes
+   * are also written into a .pb file.
    *
    * @return  true if the generation succeeded.
    */
@@ -161,6 +170,12 @@ public class BuildMetadataCppFromXml extends Command {
     try {
       Options opt = Options.parse(getCommandName(), getArgs());
       byte[] data = loadMetadataBytes(opt.getInputFilePath(), opt.getVariant() == Variant.LITE);
+
+      // Write bytes to a .pb file as well.
+      if(opt.getCreatePbFiles()){
+        writeByteData(opt, data);
+      }
+
       CppMetadataGenerator metadata = CppMetadataGenerator.create(opt.getType(), data);
 
       // TODO: Consider adding checking for correctness of file paths and access.
@@ -182,6 +197,24 @@ public class BuildMetadataCppFromXml extends Command {
       System.err.println(e.getMessage());
     }
     return false;
+  }
+
+  /**
+   * Writes the passed in byte array to a .pb file in the appropriate directory.
+   *
+   * @param (opt) Options object representing this command's arguments.
+   * @param (data) Metadata byte array to write.
+   */
+  private void writeByteData(Options opt, byte[] data) throws IOException, RuntimeException{
+      OutputStream rawProtoStream = null;
+      try {
+        File dir = new File(opt.getOutputDir());
+        rawProtoStream = openRawProtoStream(dir, opt.getType(), opt.getVariant());
+        rawProtoStream.write(data);
+        rawProtoStream.flush();
+      } finally {
+        FileUtils.closeFiles(rawProtoStream);
+      }
   }
 
   /** Loads the metadata XML file and converts its contents to a byte array. */
@@ -213,6 +246,10 @@ public class BuildMetadataCppFromXml extends Command {
   // @VisibleForTesting
   OutputStream openSourceStream(File dir, Type type, Variant variant) throws FileNotFoundException {
     return new FileOutputStream(new File(dir, variant.getBasename(type) + ".cc"));
+  }
+
+  OutputStream openRawProtoStream(File dir, Type type, Variant variant) throws FileNotFoundException {
+    return new FileOutputStream(new File(dir, variant.getBasename(type) + ".pb"));  
   }
 
   /** The charset in which our source and header files will be written. */


### PR DESCRIPTION
Adds the ability to output metadata.pb as a counterpart to metadata.cc. Instead of outputting into a char[], we can output the data raw to a file.

This is useful for Chromium, as it tries to reduce the binary size impact of this proto. See crbug.com/688642. Part 2 of this change will introduce an API for a libphonenumber client to provide a function which returns the metadata. This will allow us to compress this metadata.pb and provide a decompression function to libphonenumber, which will only decompress once if it has not been initialized.