### PR TITLE
Adding support to load metadata via function wrapper

### DIFF
--- a/cpp/src/phonenumbers/phonenumberutil.h
+++ b/cpp/src/phonenumbers/phonenumberutil.h
@@ -29,6 +29,7 @@
 #include "phonenumbers/base/memory/scoped_ptr.h"
 #include "phonenumbers/base/memory/singleton.h"
 #include "phonenumbers/phonenumber.pb.h"
+#include "phonenumbers/phonemetadata.pb.h"
 
 class TelephoneNumber;
 
@@ -218,6 +219,7 @@ class PhoneNumberUtil : public Singleton<PhoneNumberUtil> {
   // The PhoneNumberUtil is implemented as a singleton. Therefore, calling
   // GetInstance multiple times will only result in one instance being created.
   static PhoneNumberUtil* GetInstance();
+  static PhoneNumberUtil* GetInstanceWithRawMetadata(std::function<std::string ()> process_data);
 
   // Returns true if the number is a valid vanity (alpha) number such as 800
   // MICROSOFT. A valid vanity number will start with at least 3 digits and will
@@ -818,7 +820,12 @@ class PhoneNumberUtil : public Singleton<PhoneNumberUtil> {
   scoped_ptr<std::map<int, PhoneMetadata> >
       country_code_to_non_geographical_metadata_map_;
 
+  // Used to check if IntializeFromMetadata has been called for an instance.
+  bool has_used_metadata_ = false;
+
   PhoneNumberUtil();
+
+  void InitializeFromMetadata(PhoneMetadataCollection& metadata_collection);
 
   // Returns a regular expression for the possible extensions that may be found
   // in a number, for use when matching.


### PR DESCRIPTION
This adds the ability to pass in a function which will provide the metadata.

This is intended to be used along with https://github.com/google/libphonenumber/pull/2384

Chromium's plan (crbug.com/688642), is to use the .pb file in the above pull request, compress it, and save binary size. When we use libphonenumber, we would instead use the new API to provide a decompression function which would give the metadata string to libphonenumber.

We are using a passed in function to prevent (possibly expensive) **re-**retrieval of metadata.