### PR TITLE
Hungary code changes

### DIFF
--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -1199,18 +1199,6 @@ void PhoneNumberUtil::FormatNumberForMobileDialing(
         // string here.
         formatted_number->assign("");
       }
-    } else if (is_valid_number && region_code == "HU") {
-      // The national format for HU numbers doesn't contain the national prefix,
-      // because that is how numbers are normally written down. However, the
-      // national prefix is obligatory when dialing from a mobile phone, except
-      // for short numbers. As a result, we add it back here if it is a valid
-      // regular length phone number.
-      Format(number_no_extension, NATIONAL, formatted_number);
-      string hu_national_prefix;
-      GetNddPrefixForRegion(region_code, true /* strip non-digits */,
-                            &hu_national_prefix);
-      formatted_number->assign(
-          StrCat(hu_national_prefix, " ", *formatted_number));
     } else if (country_calling_code == kNanpaCountryCode) {
       // For NANPA countries, we output international format for numbers that
       // can be dialed internationally, since that always works, except for

--- a/cpp/test/phonenumbers/phonenumberutil_test.cc
+++ b/cpp/test/phonenumbers/phonenumberutil_test.cc
@@ -1214,25 +1214,6 @@ TEST_F(PhoneNumberUtilTest, FormatNumberForMobileDialing) {
       test_number, RegionCode::IT(), false, &formatted_number);
   EXPECT_EQ("", formatted_number);
 
-  // Test the special logic for Hungary, where the national prefix must be
-  // added before dialing from a mobile phone for regular length numbers, but
-  // not for short numbers.
-  test_number.set_country_code(36);
-  test_number.set_national_number(301234567ULL);
-  phone_util_.FormatNumberForMobileDialing(
-      test_number, RegionCode::HU(), false, &formatted_number);
-  EXPECT_EQ("06301234567", formatted_number);
-  phone_util_.FormatNumberForMobileDialing(
-      test_number, RegionCode::JP(), false, &formatted_number);
-  EXPECT_EQ("+36301234567", formatted_number);
-  test_number.set_national_number(104L);
-  phone_util_.FormatNumberForMobileDialing(
-      test_number, RegionCode::HU(), false, &formatted_number);
-  EXPECT_EQ("104", formatted_number);
-  phone_util_.FormatNumberForMobileDialing(
-      test_number, RegionCode::JP(), false, &formatted_number);
-  EXPECT_EQ("", formatted_number);
-
   // Test the special logic for NANPA countries, for which regular length phone
   // numbers are always output in international format, but short numbers are
   // in national format.

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -1425,14 +1425,6 @@ public class PhoneNumberUtil {
             // called within Brazil. Without that, most of the carriers won't connect the call.
             // Because of that, we return an empty string here.
             : "";
-      } else if (isValidNumber && regionCode.equals("HU")) {
-        // The national format for HU numbers doesn't contain the national prefix, because that is
-        // how numbers are normally written down. However, the national prefix is obligatory when
-        // dialing from a mobile phone, except for short numbers. As a result, we add it back here
-        // if it is a valid regular length phone number.
-        formattedNumber =
-            getNddPrefixForRegion(regionCode, true /* strip non-digits */) + " "
-            + format(numberNoExt, PhoneNumberFormat.NATIONAL);
       } else if (countryCallingCode == NANPA_COUNTRY_CODE) {
         // For NANPA countries, we output international format for numbers that can be dialed
         // internationally, since that always works, except for numbers which might potentially be

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
@@ -878,19 +878,6 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
         false));
     assertEquals("", phoneUtil.formatNumberForMobileDialing(deShortNumber, RegionCode.IT, false));
 
-    // Test the special logic for Hungary, where the national prefix must be added before dialing
-    // from a mobile phone for regular length numbers, but not for short numbers.
-    PhoneNumber huRegularNumber = new PhoneNumber().setCountryCode(36)
-        .setNationalNumber(301234567L);
-    assertEquals("06301234567", phoneUtil.formatNumberForMobileDialing(huRegularNumber,
-        RegionCode.HU, false));
-    assertEquals("+36301234567", phoneUtil.formatNumberForMobileDialing(huRegularNumber,
-        RegionCode.JP, false));
-    PhoneNumber huShortNumber = new PhoneNumber().setCountryCode(36).setNationalNumber(104L);
-    assertEquals("104", phoneUtil.formatNumberForMobileDialing(huShortNumber, RegionCode.HU,
-        false));
-    assertEquals("", phoneUtil.formatNumberForMobileDialing(huShortNumber, RegionCode.JP, false));
-
     // Test the special logic for NANPA countries, for which regular length phone numbers are always
     // output in international format, but short numbers are in national format.
     assertEquals("+16502530000", phoneUtil.formatNumberForMobileDialing(US_NUMBER,

--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -1935,16 +1935,6 @@ i18n.phonenumbers.PhoneNumberUtil.prototype.formatNumberForMobileDialing =
           // carriers won't connect the call. Because of that, we return an
           // empty string here.
           '';
-    } else if (isValidNumber && regionCode == 'HU') {
-      // The national format for HU numbers doesn't contain the national prefix,
-      // because that is how numbers are normally written down. However, the
-      // national prefix is obligatory when dialing from a mobile phone. As a
-      // result, we add it back here if it is a valid regular length phone
-      // number.
-      formattedNumber =
-          this.getNddPrefixForRegion(regionCode, true /* strip non-digits */) +
-          ' ' + this.format(numberNoExt,
-              i18n.phonenumbers.PhoneNumberFormat.NATIONAL);
     } else if (countryCallingCode ==
                i18n.phonenumbers.PhoneNumberUtil.NANPA_COUNTRY_CODE_) {
       // For NANPA countries, we output international format for numbers that

--- a/javascript/i18n/phonenumbers/phonenumberutil_test.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil_test.js
@@ -1196,28 +1196,6 @@ function testFormatNumberForMobileDialing() {
       phoneUtil.formatNumberForMobileDialing(deShortNumber,
                                              RegionCode.IT, false));
 
-  // Test the special logic for Hungary, where the national prefix must be added
-  // before dialing from a mobile phone for regular length numbers, but not for
-  // short numbers.
-  var huRegularNumber = new i18n.phonenumbers.PhoneNumber();
-  huRegularNumber.setCountryCode(36);
-  huRegularNumber.setNationalNumber(301234567);
-  assertEquals('06301234567',
-      phoneUtil.formatNumberForMobileDialing(huRegularNumber,
-                                             RegionCode.HU, false));
-  assertEquals('+36301234567',
-      phoneUtil.formatNumberForMobileDialing(huRegularNumber,
-                                             RegionCode.JP, false));
-  var huShortNumber = new i18n.phonenumbers.PhoneNumber();
-  huShortNumber.setCountryCode(36);
-  huShortNumber.setNationalNumber(104);
-  assertEquals('104',
-      phoneUtil.formatNumberForMobileDialing(huShortNumber,
-                                             RegionCode.HU, false));
-  assertEquals('',
-      phoneUtil.formatNumberForMobileDialing(huShortNumber,
-                                             RegionCode.JP, false));
-
   // Test the special logic for NANPA countries, for which regular length phone
   // numbers are always output in international format, but short numbers are in
   // national format.

--- a/resources/PhoneNumberMetadataForTesting.xml
+++ b/resources/PhoneNumberMetadataForTesting.xml
@@ -561,19 +561,6 @@
       </fixedLine>
     </territory>
 
-    <!-- Hungary -->
-    <!-- This country has special logic in formatNumberForMobileDialing which must be tested. -->
-    <territory id="HU" countryCode="36" internationalPrefix="00" nationalPrefix="06">
-      <generalDesc>
-        <nationalNumberPattern>30\d{7}</nationalNumberPattern>
-      </generalDesc>
-      <mobile>
-        <nationalNumberPattern>30\d{7}</nationalNumberPattern>
-        <possibleLengths national="9"/>
-        <exampleNumber>301234567</exampleNumber>
-      </mobile>
-    </territory>
-
     <!-- Italy -->
     <!-- http://en.wikipedia.org/wiki/%2B39 -->
     <territory id="IT" countryCode="39" internationalPrefix="00">


### PR DESCRIPTION
In coming metadata release: National prefix (06) will be present by default in national format for both fixed line and mobile numbers based on Wikipedia. So making the code ready.

For Hungary, there is special logic in formatNumberForMobileDialing() to manually add national prefix as earlier we are not adding based on metadata. So we are removing it as part of this change; and it is no more needed. Also removing the relevant test data and unit tests as because this is the only case tested for Hungary. More details in cl/265831383

Evidence: https://en.wikipedia.org/wiki/Telephone_numbers_in_Hungary