### PR TITLE
Update PhoneNumberMetadata.xml for SG mobile

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -23887,7 +23887,7 @@
         <nationalNumberPattern>
           89[01]\d{5}|
           (?:
-            8[1-8]|
+            8[1-9]|
             9[0-8]
           )\d{6}
         </nationalNumberPattern>


### PR DESCRIPTION
I recently found that a local telco had assigned someone with a number starting with `89`. 
I updated the mobile metadata for Singapore to accept numbers starting with `89`, with reference to Singapore's [Infocomm Media Development Authority's national numbering plan](https://www2.imda.gov.sg/regulations-and-licensing-listing/numbering/national-numbering-plan-and-allocation-process).

>Level ‘8’ and ‘9’ numbers are set aside for Radio Network services. 3-digit
numbers beginning with the digit ‘99’ are set aside for emergency services for
easy dialling, while 8-digit numbers are allocated for Radio Network services 

[Source](https://www2.imda.gov.sg/-/media/Imda/Files/Regulation-Licensing-and-Consultations/Frameworks-and-Policies/Numbering/National-Numbering-Plan-and-Allocation-Process/LEVEL-8-AND-9-NUMBERS-23-Oct-2017.pdf?la=en)

Numbers starting with `80` are reserved for toll free services.

> ‘800’ is the prefix for International Toll Free Services (ITFS) and Home
Country Direct Service (HCDS). The dialling number of the service consists
of 10 digits - the ‘800’ access code followed by a 7-digit number.

[Source](https://www2.imda.gov.sg/-/media/Imda/Files/Regulation-Licensing-and-Consultations/Frameworks-and-Policies/Numbering/National-Numbering-Plan-and-Allocation-Process/800-NUMBERS-23-Oct-2017.pdf?la=en)