### PR TITLE
Åland Islands geo tagging

### DIFF
--- a/resources/geocoding/en/358.txt
+++ b/resources/geocoding/en/358.txt
@@ -22,6 +22,7 @@
 35815|Mikkeli
 35816|Lapland
 35817|Kuopio
+35818|Åland Islands
 35819|Uusimaa
 35821|Turku/Pori
 35822|Turku/Pori

--- a/resources/geocoding/fi/358.txt
+++ b/resources/geocoding/fi/358.txt
@@ -22,6 +22,7 @@
 35815|Mikkeli
 35816|Lappi
 35817|Kuopio
+35818|Ahvenanmaa
 35819|Uusimaa
 35821|Turku/Pori
 35822|Turku/Pori

--- a/resources/geocoding/sv/358.txt
+++ b/resources/geocoding/sv/358.txt
@@ -22,6 +22,7 @@
 35815|St Michel
 35816|Lappland
 35817|Kuopio
+35818|Åland
 35819|Nyland
 35821|Åbo/Björneborg
 35822|Åbo/Björneborg


### PR DESCRIPTION
Complemented geo tagging for Åland Islands. All according to the description in http://en.wikipedia.org/wiki/+358
The official numbering plan of Finland can be found at https://www.traficom.fi/sites/default/files/media/file/Suomen_numerointisuunnitelma.pdf