### PR TITLE
Added area code 672 (British Columbia)

### DIFF
--- a/resources/geocoding/en/1.txt
+++ b/resources/geocoding/en/1.txt
@@ -18827,6 +18827,7 @@
 1667|Maryland
 1669|California
 1671646|Tamuning
+1672|British Columbia
 1678|Georgia
 1678208|Cumming, GA
 1678225|Lawrenceville, GA


### PR DESCRIPTION
Added 672 area code for British Columbia phone numbers.
My number is +1 672 999 **** and I can not add this number to my google account

This area code was added on May 4, here is the proof: https://www.eastlink.ca/telephone/newareacode