### PR TITLE
Fix javascript build issues

### DIFF
--- a/javascript/build.xml
+++ b/javascript/build.xml
@@ -31,22 +31,18 @@
         <arg line='-f "--compilation_level=@{compilationlevel}"' />
         <arg line='-f "--warning_level=VERBOSE"' />
         <arg line='-f "--jscomp_error=accessControls"' />
-        <arg line='-f "--jscomp_error=ambiguousFunctionDecl"' />
         <arg line='-f "--jscomp_error=checkDebuggerStatement"' />
         <arg line='-f "--jscomp_error=checkRegExp"' />
         <arg line='-f "--jscomp_error=checkTypes"' />
         <arg line='-f "--jscomp_error=checkVars"' />
         <arg line='-f "--jscomp_error=const"' />
         <arg line='-f "--jscomp_error=constantProperty"' />
-        <arg line='-f "--jscomp_error=deprecated"' />
         <arg line='-f "--jscomp_error=duplicate"' />
         <arg line='-f "--jscomp_error=duplicateMessage"' />
         <arg line='-f "--jscomp_error=es5Strict"' />
         <arg line='-f "--jscomp_error=externsValidation"' />
         <arg line='-f "--jscomp_error=extraRequire"' />
-        <arg line='-f "--jscomp_error=fileoverviewTags"' />
         <arg line='-f "--jscomp_error=globalThis"' />
-        <arg line='-f "--jscomp_error=internetExplorerChecks"' />
         <arg line='-f "--jscomp_error=invalidCasts"' />
         <arg line='-f "--jscomp_error=misplacedTypeAnnotation"' />
         <arg line='-f "--jscomp_error=missingProperties"' />


### PR DESCRIPTION
I encountered some issues when building the javascript library. After successfully compiling the closure-compiler, I ran `ant -f javascript/build.xml compile-demo` as the javascript/README.md suggests. The first error I saw was:

```
     [exec] java.lang.NullPointerException: No warning class for name: ambiguousFunctionDecl
     [exec] 	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:980)
     [exec] 	at com.google.javascript.jscomp.DiagnosticGroups.setWarningLevel(DiagnosticGroups.java:697)
     [exec] 	at com.google.javascript.jscomp.AbstractCommandLineRunner.setWarningGuardOptions(AbstractCommandLineRunner.java:327)
     [exec] 	at com.google.javascript.jscomp.AbstractCommandLineRunner.setRunOptions(AbstractCommandLineRunner.java:368)
     [exec] 	at com.google.javascript.jscomp.AbstractCommandLineRunner.doRun(AbstractCommandLineRunner.java:1107)
     [exec] 	at com.google.javascript.jscomp.AbstractCommandLineRunner.run(AbstractCommandLineRunner.java:546)
     [exec] 	at com.google.javascript.jscomp.CommandLineRunner.main(CommandLineRunner.java:2131)
     [exec] calcdeps.py: JavaScript compilation failed.
```

It appears that `ambiguousFunctionDecl` has been removed in closure-compiler: https://github.com/google/closure-compiler/commit/391c6c47f8089870fe89839521c0b135051cedf7

Similar deleted warning classes are:
fileoverviewTags https://github.com/google/closure-compiler/commit/04cba67d03eff670048dc96a6f72944e8e0e8616
internetExplorerChecks https://github.com/google/closure-compiler/commit/baab83533b1dbeaad1bf5d1f634cb252d0de877d

So I remove these warnings from the `build.xml`.

After that, I tried compiling again, and saw these errors about some deprecated syntax:

```
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/base.js:2251: ERROR - [JSC_DEPRECATED_PROP_REASON] Property defineClass of type goog has been deprecated: Use ES6 class syntax instead.
     [exec]   if (!goog.defineClass.SEAL_CLASS_INSTANCES) {
     [exec]        ^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/base.js:2259: ERROR - [JSC_DEPRECATED_PROP_REASON] Property defineClass of type goog has been deprecated: Use ES6 class syntax instead.
     [exec]   var superclassSealable = !goog.defineClass.isUnsealable_(superClass);
     [exec]                             ^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/base.js:2328: ERROR - [JSC_DEPRECATED_PROP_REASON] Property defineClass of type goog has been deprecated: Use ES6 class syntax instead.
     [exec]   for (var i = 0; i < goog.defineClass.OBJECT_PROTOTYPE_FIELDS_.length; i++) {
     [exec]                       ^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/base.js:2329: ERROR - [JSC_DEPRECATED_PROP_REASON] Property defineClass of type goog has been deprecated: Use ES6 class syntax instead.
     [exec]     key = goog.defineClass.OBJECT_PROTOTYPE_FIELDS_[i];
     [exec]           ^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/base.js:2346: ERROR - [JSC_DEPRECATED_PROP_REASON] Property defineClass of type goog has been deprecated: Use ES6 class syntax instead.
     [exec]   if (!COMPILED && goog.defineClass.SEAL_CLASS_INSTANCES) {
     [exec]                    ^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/base.js:4002: ERROR - [JSC_DEPRECATED_PROP] Property TrustedTypes of type global this has been deprecated.
     [exec]   var policyFactory = goog.global.trustedTypes || goog.global.TrustedTypes;
     [exec]                                                   ^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/dom.js:160: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertElement of type goog.asserts has been deprecated: Use goog.asserts.dom.assertIsElement instead.
     [exec]       goog.asserts.assertElement(element, 'No element found with id: ' + id);
     [exec]       ^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/dom.js:840: ERROR - [JSC_DEPRECATED_PROP_REASON] Property extend of type goog.object has been deprecated: Prefer Object.assign
     [exec]       goog.object.extend(clone, attributes);
     [exec]       ^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:207: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLFormElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlFormElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLFormElement(form).action =
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:238: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLButtonElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlButtonElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLButtonElement(button).formAction =
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:268: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLInputElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlInputElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLInputElement(input).formAction =
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:313: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLAnchorElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlAnchorElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLAnchorElement(anchor);
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:338: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLImageElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlImageElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLImageElement(imageElement);
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:363: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLAudioElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlAudioElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLAudioElement(audioElement);
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:388: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLVideoElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlVideoElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLVideoElement(videoElement);
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:415: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLEmbedElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlEmbedElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLEmbedElement(embed);
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:435: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLFrameElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlFrameElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLFrameElement(frame);
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:455: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLIFrameElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlIFrameElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLIFrameElement(iframe);
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:474: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLIFrameElement of type goog.dom.asserts has been deprecated 12      [exec] java.lang.NullPointerException: No warning class for name: ambiguousFunctionDecl
: Use goog.asserts.dom.assertIsHtmlIFrameElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLIFrameElement(iframe);
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:505: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLLinkElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlLinkElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLLinkElement(link);
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:539: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLObjectElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlObjectElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLObjectElement(object);
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:559: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLScriptElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlScriptElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLScriptElement(script);
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/dom/safe.js:586: ERROR - [JSC_DEPRECATED_PROP_REASON] Property assertIsHTMLScriptElement of type goog.dom.asserts has been deprecated: Use goog.asserts.dom.assertIsHtmlScriptElement instead.
     [exec]   goog.dom.asserts.assertIsHTMLScriptElement(script);
     [exec]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     [exec]
     [exec] /Users/lee/ClickToCloud/git/closure-library/closure/goog/string/string.js:1111: ERROR - [JSC_DEPRECATED_PROP_REASON] Property now of type goog has been deprecated: Use Date.now
     [exec]       Math.abs(Math.floor(Math.random() * x) ^ goog.now()).toString(36);
     [exec]                                                ^^^^^^^^
     [exec]
     [exec] 24 error(s), 0 warning(s), 98.7% typed
     [exec] calcdeps.py: JavaScript compilation failed.
```

I believe these can only be fixed from the closure-library. But we can skip turning these warnings to errors by removing the `deprecated` warning.