### PR TITLE
Add JavaScript demo for AsYouTypeFormatter

### DIFF
--- a/javascript/i18n/phonenumbers/demo.html
+++ b/javascript/i18n/phonenumbers/demo.html
@@ -42,7 +42,11 @@ limitations under the License.
 <form>
   <p>
   Specify a Phone Number:
-  <input type="text" name="phoneNumber" id="phoneNumber" size="25" />
+  <input type="text" name="phoneNumber" id="phoneNumber" size="25" oninput="phoneNumberFormatter" />
+  </p>
+  <p>
+  <input type="checkbox" name="formatAsYouType" id="formatAsYouType" />
+  Format as you type
   </p>
   <p>
   Specify a Default Country:

--- a/javascript/i18n/phonenumbers/demo.js
+++ b/javascript/i18n/phonenumbers/demo.js
@@ -171,3 +171,50 @@ function phoneNumberParser() {
 }
 
 goog.exportSymbol('phoneNumberParser', phoneNumberParser);
+
+let savedValue = "";
+let formatter = null;
+
+function phoneNumberFormatter() {
+  const $ = goog.dom.getElement;
+  
+  const formatAsYouType = $('formatAsYouType').checked;
+  if (!formatAsYouType) {
+    savedValue = "";
+    formatter = null;
+    return;
+  }
+
+  const phoneNumber = $('phoneNumber').value;
+  const regionCode = $('defaultCountry').value.toUpperCase();
+  
+  if (!formatter) {
+    savedValue = phoneNumber;
+    formatter = new i18n.phonenumbers.AsYouTypeFormatter(regionCode);
+
+    for (const char of phoneNumber) {
+      formatter.inputDigit(char);
+    }
+  }
+
+  if (phoneNumber.startsWith(savedValue)) {
+    // User appended characters to the input.
+    // Add newly typed characters to formatter.
+    const newChars = phoneNumber.substring(savedValue.length);
+    for (const char of newChars) {
+      savedValue = formatter.inputDigit(char);
+    }
+  } else {
+    // User changed the input in a different way than appending characters.
+    // Clear the formatter and add all characters.
+    savedValue = "";
+    formatter.clear();
+    for (const char of phoneNumber) {
+      savedValue = formatter.inputDigit(char);
+    }
+  }
+  
+  $('phoneNumber').value = savedValue;
+}
+
+goog.exportSymbol('phoneNumberFormatter', phoneNumberFormatter);


### PR DESCRIPTION
The repository contains a JavaScript version of the `AsYouTypeFormatter`, but doesn't show off actual as-you-type formatting in the demo. This pull request currently contains a naive implementation of as-you-type formatting of the phone number field in the demo when a new checkbox is checked.

One might actually want to, for example:
1. Move this out into a separate demo page.
2. Change the as-you-type input box to a design that indicates and enforces that it's _append only_, since the `AsYouTypeFormatter `doesn't support deleting digits that have already been input, changing digits, or adding digits in the middle of the phone number.
3. Ensure that JavaScript works with all browsers that the demo is supposed to support (which are those?) and change usage and placement of state variables `savedValue` and `formatter`.
4. Update the compiled version of the demo, or create a compiled version of the separate demo page.

However, I hope this pull request can at least shed light on whether an as-you-type formatting demo is desirable. The issue tracker at https://issuetracker.google.com/issues?q=componentid:192347 seems to only contain issues regarding metadata. Having read the contribution guidelines, I'm still unsure if I should file an issue there with regards to demo improvements like this.