### PR TITLE
Update 243.txt

### DIFF
--- a/resources/carrier/en/243.txt
+++ b/resources/carrier/en/243.txt
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-24380|Supercell
+24380|Orange
 24381|Vodacom
 24382|Vodacom
-24384|CCT
+24384|Orange
+24385|Orange
 24388|Yozma Timeturns sprl -YTT
-24389|Sait-Telecom (Oasis)
+24389|Orange
 24390|Africell
 24391|Africell
-24397|Zain
-24398|Zain
-24399|Zain
+24397|Airtel
+24398|Airtel
+24399|Airtel


### PR DESCRIPTION
## Supercell, CCT, and Sait-Telecom (Oasis) are now Orange. 
- Orange -> Tigo (Saint-T) https://www.commsupdate.com/articles/2016/04/21/orange-completes-100-acquisition-of-tigo-drc/

- Orange -> CCT https://www.commsupdate.com/articles/2011/10/24/ft-completes-usd196-million-cct-deal/

-  Orange Prefix https://support.libon.com/hc/en-us/articles/115006119648-List-of-Orange-DR-Congo-prefixes


## Zain is now Airtel.﻿
- Zain -> Airtel https://www.commsupdate.com/articles/2010/03/31/bharti-inks-agreement-for-zains-african-subsidiaries/

