### PR TITLE
[Japan] Fix wrong prefecture name in geocoding in Japan

### DIFF
--- a/resources/geocoding/en/81.txt
+++ b/resources/geocoding/en/81.txt
@@ -1126,7 +1126,7 @@
 819556|Karatsu, Saga
 819557|Karatsu, Saga
 819558|Karatsu, Saga
-81956|Sasebo, Japan
+81956|Sasebo, Nagasaki
 819572|Isahaya, Nagasaki
 819573|Isahaya, Nagasaki
 819574|Isahaya, Nagasaki


### PR DESCRIPTION
## Abstract
I found a wrong prefecture name in geocoding resource file in Japan (+81).
Sasebo is a city in Nagasaki pref., and I think the prefix number is not special.
So, I think we need to change "Japan" => "Nagasaki".

I'm not familiar with this codebase, so I'm not sure if I can edit this resource file directly.

## Metadata
*   Country: Japan
*   Example number(s) and/or range(s): +81956
*   Number type ("fixed-line", "mobile", "short code", etc.): fixed-line
*   For short codes, cost and dialing restrictions: n/a
*   Where or whom did you get the number(s) from: n/a
*   Authoritative evidence (e.g. national numbering plan, operator announcement): https://en.wikipedia.org/wiki/List_of_dialing_codes_in_Japan  
https://www.soumu.go.jp/main_content/000141817.pdf (Japanese)  
According to the goverment document above, the prefix number is mainly used in Sasebo city in Nagasaki pref.
*   Link from demo (http://libphonenumber.appspot.com) showing error: n/a