### PR TITLE
Add new c++ build options for use protobuf-lite

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -81,6 +81,7 @@ endfunction (find_required_program)
 option ("BUILD_GEOCODER" "Build the offline phone number geocoder" "ON")
 option ("REGENERATE_METADATA" "Regenerate metadata instead of using it from the source tree" "ON")
 option ("USE_ALTERNATE_FORMATS" "Use alternate formats" "ON")
+option ("USE_PROTOBUF_LITE" "Link to protobuf-lite" "OFF")
 option ("USE_BOOST" "Use Boost" "ON")
 option ("USE_ICU_REGEXP" "Use ICU regexp engine" "ON")
 option ("USE_LITE_METADATA" "Use lite metadata" "OFF")
@@ -126,9 +127,15 @@ if (${USE_RE2} STREQUAL "ON")
   find_required_library (RE2 re2/re2.h re2 "Google RE2")
 endif ()
 
-find_required_library (PROTOBUF google/protobuf/message_lite.h protobuf
-                       "Google Protocol Buffers")
-check_library_version (PC_PROTOBUF protobuf>=2.4)
+if (${USE_PROTOBUF_LITE} STREQUAL "ON")
+  find_required_library (PROTOBUF google/protobuf/message_lite.h protobuf-lite
+                         "Google Protocol Buffers")
+  check_library_version (PC_PROTOBUF protobuf-lite>=2.4)
+else ()
+  find_required_library (PROTOBUF google/protobuf/message_lite.h protobuf
+                         "Google Protocol Buffers")
+  check_library_version (PC_PROTOBUF protobuf>=2.4)
+endif ()
 
 find_required_library (ICU_UC unicode/uchar.h icuuc "ICU")
 check_library_version (PC_ICU_UC icu-uc>=4.4)


### PR DESCRIPTION
Original commit from  Timur Kristóf (#2363)

Add ability for the C++ library to link against protobuf-lite. .

USE_PROTOBUF_LITE - When this is set to ON then it links against protobuf-lite instead of the full version of protobuf. As far as I could see the metadata has option optimize_for = LITE_RUNTIME; so it should be safe to use the lite version. This is useful when you want to save some disk space. The default is OFF.

see https://github.com/google/libphonenumber/pull/2363 for original PR

discussion about protobuf vs protobif lite :
https://stackoverflow.com/questions/6405767/protocol-buffer-lite-versus-regular-protocol-buffer

@Venemo  @penmetsaa 