### PR TITLE
Minor README.md spelling fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ releases and the demo may be at either version.
 
 The [JavaScript
 demo](https://rawgit.com/google/libphonenumber/master/javascript/i18n/phonenumbers/demo-compiled.html)
-may be run at various tags; this link will take you to `master`. [JS demo link not working as RawGit is depricated.]
+may be run at various tags; this link will take you to `master`. [JS demo link not working as RawGit is deprecated.]
 TODO to host in alternative platform.
 
 # Java code


### PR DESCRIPTION
Change `depricated` to `deprecated` in README.md