### PR TITLE
Use "in house" helper for assertThrows() which is otherwise only available internally.

### DIFF
--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/DigitSequenceTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/DigitSequenceTest.java
@@ -17,7 +17,7 @@ package com.google.i18n.phonenumbers.metadata;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.i18n.phonenumbers.metadata.DigitSequence.domain;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/RangeSpecificationTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/RangeSpecificationTest.java
@@ -21,7 +21,7 @@ import static com.google.i18n.phonenumbers.metadata.DigitSequence.domain;
 import static com.google.i18n.phonenumbers.metadata.RangeSpecification.ALL_DIGITS_MASK;
 import static com.google.i18n.phonenumbers.metadata.RangeSpecification.parse;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.Range;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/RangeTreeTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/RangeTreeTest.java
@@ -20,7 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.i18n.phonenumbers.metadata.DigitSequence.domain;
 import static com.google.i18n.phonenumbers.metadata.testing.RangeTreeSubject.assertThat;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/i18n/PhoneRegionTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/i18n/PhoneRegionTest.java
@@ -17,7 +17,7 @@ package com.google.i18n.phonenumbers.metadata.i18n;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import java.util.stream.Stream;
 import org.junit.Test;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/i18n/SimpleLanguageTagTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/i18n/SimpleLanguageTagTest.java
@@ -16,7 +16,7 @@
 package com.google.i18n.phonenumbers.metadata.i18n;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/AltFormatSpecTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/AltFormatSpecTest.java
@@ -17,7 +17,7 @@ package com.google.i18n.phonenumbers.metadata.model;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import com.google.i18n.phonenumbers.metadata.RangeSpecification;
 import com.google.i18n.phonenumbers.metadata.model.FormatSpec.FormatTemplate;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/FormatSpecTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/FormatSpecTest.java
@@ -18,7 +18,7 @@ package com.google.i18n.phonenumbers.metadata.model;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static java.util.Optional.empty;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import com.google.i18n.phonenumbers.metadata.model.FormatSpec.FormatTemplate;
 import java.util.Optional;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/AssignmentTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/AssignmentTest.java
@@ -17,7 +17,7 @@ package com.google.i18n.phonenumbers.metadata.table;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/ChangeTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/ChangeTest.java
@@ -18,7 +18,7 @@ package com.google.i18n.phonenumbers.metadata.table;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.i18n.phonenumbers.metadata.testing.RangeTreeSubject.assertThat;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import com.google.i18n.phonenumbers.metadata.RangeSpecification;
 import com.google.i18n.phonenumbers.metadata.RangeTree;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/ColumnGroupTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/ColumnGroupTest.java
@@ -16,7 +16,7 @@
 package com.google.i18n.phonenumbers.metadata.table;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.i18n.phonenumbers.metadata.i18n.PhoneRegion;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/ColumnTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/ColumnTest.java
@@ -21,7 +21,7 @@ import static com.google.i18n.phonenumbers.metadata.proto.Types.ValidNumberType.
 import static com.google.i18n.phonenumbers.metadata.proto.Types.XmlNumberType.XML_UNKNOWN;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import com.google.i18n.phonenumbers.metadata.proto.Types.ValidNumberType;
 import com.google.i18n.phonenumbers.metadata.proto.Types.XmlNumberType;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/CsvParserTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/CsvParserTest.java
@@ -18,7 +18,7 @@ package com.google.i18n.phonenumbers.metadata.table;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.i18n.phonenumbers.metadata.table.CsvParser.rowMapper;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.i18n.phonenumbers.metadata.table.CsvParser.RowMapper;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/CsvTableTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/CsvTableTest.java
@@ -32,7 +32,7 @@ import static com.google.i18n.phonenumbers.metadata.table.CsvTable.DiffMode.ALL;
 import static com.google.i18n.phonenumbers.metadata.table.CsvTable.DiffMode.CHANGES;
 import static com.google.i18n.phonenumbers.metadata.table.CsvTable.DiffMode.LHS;
 import static com.google.i18n.phonenumbers.metadata.table.CsvTable.DiffMode.RHS;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/RangeTableTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/RangeTableTest.java
@@ -26,7 +26,7 @@ import static com.google.i18n.phonenumbers.metadata.proto.Types.ValidNumberType.
 import static com.google.i18n.phonenumbers.metadata.testing.RangeTableSubject.assertThat;
 import static com.google.i18n.phonenumbers.metadata.testing.RangeTreeSubject.assertThat;
 import static java.util.stream.IntStream.rangeClosed;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Table;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/SchemaTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/SchemaTest.java
@@ -18,7 +18,7 @@ package com.google.i18n.phonenumbers.metadata.table;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static com.google.i18n.phonenumbers.metadata.proto.Types.ValidNumberType.UNKNOWN;
-import static org.junit.Assert.assertThrows;
+import static com.google.i18n.phonenumbers.metadata.testing.AssertUtil.assertThrows;
 
 import com.google.i18n.phonenumbers.metadata.i18n.PhoneRegion;
 import com.google.i18n.phonenumbers.metadata.proto.Types.ValidNumberType;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/testing/AssertUtil.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/testing/AssertUtil.java
@@ -1,0 +1,22 @@
+package com.google.i18n.phonenumbers.metadata.testing;
+
+/** Additional useful assertion methods for testing. */
+public final class AssertUtil {
+
+  /** Asserts the given code threw the expected exception, and returns it for further checking. */
+  public static <T extends Throwable> T assertThrows(Class<T> clazz, Runnable fn) {
+    String message;
+    try {
+      fn.run();
+      message = String.format("expected exception (%s) was not thrown", clazz.getSimpleName());
+    } catch (Throwable t) {
+      if (clazz.isInstance(t)) {
+        return clazz.cast(t);
+      }
+      message = String.format("expected (%s), but caught: %s", clazz.getSimpleName(), t);
+    }
+    throw new AssertionError(message);
+  }
+
+  private AssertUtil() {}
+}


### PR DESCRIPTION
PiperOrigin-RevId: 320004982

Code by Googler's only, so CLA is implicit.