### PR TITLE
Fixing up the JavaDoc to remove serious HTML violations.

### DIFF
--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -49,6 +49,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <source>8</source>
+          <nohelp>true</nohelp>
+          <quiet>true</quiet>
+          <doclint>all,-missing</doclint>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/metadata/src/main/java/com/google/i18n/phonenumbers/metadata/RangeSpecification.java
+++ b/metadata/src/main/java/com/google/i18n/phonenumbers/metadata/RangeSpecification.java
@@ -425,7 +425,7 @@ public final class RangeSpecification implements Comparable<RangeSpecification> 
   }
 
   /**
-   * Returns the bitmask of the Nth range in this specification. Bit-X (0<= X <= 9) corresponds to
+   * Returns the bitmask of the Nth range in this specification. Bit-X (0 ≤ X ≤ 9) corresponds to
    * the digit with value X. As every range in a specification must match at least one digit, this
    * mask can never be zero.
    */

--- a/metadata/src/main/java/com/google/i18n/phonenumbers/metadata/model/FormatSpec.java
+++ b/metadata/src/main/java/com/google/i18n/phonenumbers/metadata/model/FormatSpec.java
@@ -240,15 +240,6 @@ public abstract class FormatSpec {
     // formatting around the first group (i.e. never "(XXX) XXX XXX") which makes sense since
     // international formats cannot be assumed to be read by people with local knowledge.
 
-    // TODO: To reactivate this check after we are sure that first digit of
-    // SN of MX is no more 1 and need not to be swallowed when formatting i.e after parsing change.
-    // Context: We have disabled the following check to fix a MX formatting issue i.e using this
-    // logic {X>} to remove the mobile token(1) in international format, which is the first digit of
-    // the mobile subscriber number. More details in b/111967450. In general, international
-    // format should not have such special formatting. Can be fixed as part of b/138727490.
-
-    // checkArgument(!intl.getXmlPrefix().isPresent(),
-    //    "international format specifier must not have separate prefix: %s", spec);
     checkArgument(
         !intl.hasNationalPrefix(),
         "international format specifier must not contain national prefix: %s",
@@ -471,10 +462,10 @@ public abstract class FormatSpec {
      *
      * <p>For example given the following templates:
      * <ul>
-     *   <li>{@code "XXX XXX-XXX"} ==> {@code "$1 $2-$3"}
-     *   <li>{@code "(#XXX) XXX-XXX"} ==> {@code "$1 $2-$3"} (the prefix is hoisted)
-     *   <li>{@code "#{XXX>123} XXX-XXX"} ==> {@code "$2-$3"} ($1 was replaced and hoisted)
-     *   <li>{@code "{X>}XXX-XXX"} ==> {@code "$2-$3"} ($1 was removed)
+     *   <li>{@code "XXX XXX-XXX"} ⟹ {@code "$1 $2-$3"}
+     *   <li>{@code "(#XXX) XXX-XXX"} ⟹ {@code "$1 $2-$3"} (the prefix is hoisted)
+     *   <li>{@code "#{XXX>123} XXX-XXX"} ⟹ {@code "$2-$3"} ($1 was replaced and hoisted)
+     *   <li>{@code "{X>}XXX-XXX"} ⟹ {@code "$2-$3"} ($1 was removed)
      * </ul>
      */
     public String getXmlFormat() {
@@ -500,10 +491,10 @@ public abstract class FormatSpec {
      *
      * <p>For example given the following templates:
      * <ul>
-     *   <li>{@code "XXX XXX-XXX"} ==> XML prefix is empty
-     *   <li>{@code "(#XXX) XXX-XXX"} ==> {@code "($NP$FG)"}
-     *   <li>{@code "#{XXX>123} XXX-XXX"} ==> {@code "$NP123 $FG"}
-     *   <li>{@code "{X>}XXX-XXX"} ==> XML prefix is empty (but the format will not contain $1)
+     *   <li>{@code "XXX XXX-XXX"} ⟹ XML prefix is empty
+     *   <li>{@code "(#XXX) XXX-XXX"} ⟹ {@code "($NP$FG)"}
+     *   <li>{@code "#{XXX>123} XXX-XXX"} ⟹ {@code "$NP123 $FG"}
+     *   <li>{@code "{X>}XXX-XXX"} ⟹ XML prefix is empty (but the format will not contain $1)
      * </ul>
      */
     public Optional<String> getXmlPrefix() {

--- a/metadata/src/main/java/com/google/i18n/phonenumbers/metadata/model/RangesTableSchema.java
+++ b/metadata/src/main/java/com/google/i18n/phonenumbers/metadata/model/RangesTableSchema.java
@@ -204,7 +204,7 @@ public final class RangesTableSchema {
   /** The ID of the format assigned to a range. */
   public static final Column<String> FORMAT = Column.ofString("Format");
 
-  /** An '&'-separated list of timezone IDs associated with this range. */
+  /** An '&amp;'-separated list of timezone IDs associated with this range. */
   public static final Column<Timezones> TIMEZONE = Timezones.column("Timezone");
 
   /** The "Region:XX" column group in the range table. */

--- a/metadata/src/main/java/com/google/i18n/phonenumbers/metadata/table/RangeTable.java
+++ b/metadata/src/main/java/com/google/i18n/phonenumbers/metadata/table/RangeTable.java
@@ -613,7 +613,7 @@ public final class RangeTable {
    *
    * <p>An example of an "impossible" prefix would be if "123" has value A, "1234" has value B and
    * "12345" has value A again. In this case there is no prefix which can distinguish A and B
-   * (the calculated map would be { "123" => A, "1234" => B }). In this situation, testing for the
+   * (the calculated map would be { "123" ⟹ A, "1234" ⟹ B }). In this situation, testing for the
    * longer prefix would help preserve as much of the original mapping as possible, but it would
    * never be possible to correctly distinguish all inputs.
    */

--- a/metadata/src/main/java/com/google/i18n/phonenumbers/metadata/table/Schema.java
+++ b/metadata/src/main/java/com/google/i18n/phonenumbers/metadata/table/Schema.java
@@ -88,13 +88,14 @@ public abstract class Schema {
    * is just the column name. For group columns, the key takes the form "prefix:suffix", where the
    * prefix is the name of the "prototype" column, and the "suffix" is an ID of a value within the
    * group. For example:
-   * <p> {@oode
+   *
+   * <pre> {@code
    * // Schema has a plain column called "Type" in it.
    * typeCol = table.getColumn("Type");
    *
    * // Schema has a group called "Region" in it which can parse RegionCodes.
    * usRegionCol = table.getColumn("Region:US");
-   * }</p>
+   * }</pre>
    */
   public Column<?> getColumn(String key) {
     int split = key.indexOf(':');


### PR DESCRIPTION
PiperOrigin-RevId: 320135887

The JavaDoc still (deliberately) doesn't use @param and @return everywhere, but these "errors" are suppressed by the "-missing" option. Overly repetitive documentation, where information is stated in the field/method description and repeated in parameter/return declarations adds maintenance burden for very little benefit.

Once this is in, "mvn javadoc:javadoc" should produce the public JavaDoc site under <project>/target/site/apidocs.