### PR TITLE
Fix somes warning when compiling VS2019 target

### DIFF
--- a/cpp/src/phonenumbers/asyoutypeformatter.cc
+++ b/cpp/src/phonenumbers/asyoutypeformatter.cc
@@ -200,7 +200,7 @@ void AsYouTypeFormatter::GetAvailableFormats(const string& leading_digits) {
 void AsYouTypeFormatter::NarrowDownPossibleFormats(
     const string& leading_digits) {
   const int index_of_leading_digits_pattern =
-      leading_digits.length() - kMinLeadingDigitsLength;
+      static_cast<int>(leading_digits.length() - kMinLeadingDigitsLength);
 
   for (list<const NumberFormat*>::iterator it = possible_formats_.begin();
        it != possible_formats_.end(); ) {
@@ -453,8 +453,8 @@ bool AsYouTypeFormatter::AbleToExtractLongerNdd() {
     // Remove the previously extracted NDD from prefixBeforeNationalNumber. We
     // cannot simply set it to empty string because people sometimes incorrectly
     // enter national prefix after the country code, e.g. +44 (0)20-1234-5678.
-    int index_of_previous_ndd =
-        prefix_before_national_number_.find_last_of(extracted_national_prefix_);
+    int index_of_previous_ndd = static_cast<int>(
+        prefix_before_national_number_.find_last_of(extracted_national_prefix_));
     prefix_before_national_number_.resize(index_of_previous_ndd);
   }
   string new_national_prefix;
@@ -525,7 +525,7 @@ int AsYouTypeFormatter::GetRememberedPosition() const {
 void AsYouTypeFormatter::AppendNationalNumber(const string& national_number,
                                               string* phone_number) const {
   int prefix_before_national_number_length =
-      prefix_before_national_number_.size();
+      static_cast<int>(prefix_before_national_number_.size());
   if (should_add_space_after_national_prefix_ &&
       prefix_before_national_number_length > 0 &&
       prefix_before_national_number_.at(
@@ -571,7 +571,7 @@ void AsYouTypeFormatter::AttemptToChooseFormattingPattern(
 
 void AsYouTypeFormatter::InputAccruedNationalNumber(string* number) {
   DCHECK(number);
-  int length_of_national_number = national_number_.length();
+  int length_of_national_number = static_cast<int>(national_number_.length());
 
   if (length_of_national_number > 0) {
     string temp_national_number;
@@ -621,8 +621,8 @@ void AsYouTypeFormatter::RemoveNationalPrefixFromNationalNumber(
     // Since some national prefix patterns are entirely optional, check that a
     // national prefix could actually be extracted.
     if (pattern.Consume(consumed_input.get())) {
-      start_of_national_number =
-          national_number_.length() - consumed_input->ToString().length();
+      start_of_national_number = static_cast<int>(
+          national_number_.length() - consumed_input->ToString().length());
       if (start_of_national_number > 0) {
         // When the national prefix is detected, we use international formatting
         // rules instead of national ones, because national formatting rules
@@ -650,9 +650,9 @@ bool AsYouTypeFormatter::AttemptToExtractIdd() {
 
   if (international_prefix.Consume(consumed_input.get())) {
     is_complete_number_ = true;
-    const int start_of_country_code =
+    const int start_of_country_code = static_cast<int>(
         accrued_input_without_formatting_.length() -
-        consumed_input->ToString().length();
+        consumed_input->ToString().length());
 
     national_number_.clear();
     accrued_input_without_formatting_.tempSubString(start_of_country_code)
@@ -758,7 +758,7 @@ int AsYouTypeFormatter::ConvertUnicodeStringPosition(const UnicodeString& s,
   }
   string substring;
   s.tempSubString(0, pos).toUTF8String(substring);
-  return substring.length();
+  return static_cast<int>(substring.length());
 }
 
 }  // namespace phonenumbers

--- a/cpp/src/phonenumbers/normalize_utf8.h
+++ b/cpp/src/phonenumbers/normalize_utf8.h
@@ -26,7 +26,7 @@ struct NormalizeUTF8 {
   static string NormalizeDecimalDigits(const string& number) {
     string normalized;
     UnicodeText number_as_unicode;
-    number_as_unicode.PointToUTF8(number.data(), number.size());
+    number_as_unicode.PointToUTF8(number.data(), static_cast<int>(number.size()));
     for (UnicodeText::const_iterator it = number_as_unicode.begin();
          it != number_as_unicode.end();
          ++it) {

--- a/cpp/src/phonenumbers/phonenumbermatch.cc
+++ b/cpp/src/phonenumbers/phonenumbermatch.cc
@@ -47,11 +47,11 @@ int PhoneNumberMatch::start() const {
 }
 
 int PhoneNumberMatch::end() const {
-  return start_ + raw_string_.length();
+  return static_cast<int>(start_ + raw_string_.length());
 }
 
 int PhoneNumberMatch::length() const {
-  return raw_string_.length();
+  return static_cast<int>(raw_string_.length());
 }
 
 const string& PhoneNumberMatch::raw_string() const {

--- a/cpp/src/phonenumbers/phonenumbermatcher.cc
+++ b/cpp/src/phonenumbers/phonenumbermatcher.cc
@@ -572,8 +572,8 @@ bool PhoneNumberMatcher::ExtractInnerMatch(const string& candidate, int offset,
     string group;
     while ((*regex)->FindAndConsume(candidate_input.get(), &group) &&
            max_tries_ > 0) {
-      int group_start_index = candidate.length() -
-          candidate_input->ToString().length() - group.length();
+      int group_start_index = static_cast<int>(candidate.length() -
+          candidate_input->ToString().length() - group.length());
       if (is_first_match) {
         // We should handle any group before this one too.
         string first_group_only = candidate.substr(0, group_start_index);
@@ -660,7 +660,7 @@ bool PhoneNumberMatcher::Find(int index, PhoneNumberMatch* match) {
   string candidate;
   while ((max_tries_ > 0) &&
          reg_exps_->pattern_->FindAndConsume(text.get(), &candidate)) {
-    int start = text_.length() - text->ToString().length() - candidate.length();
+    int start = static_cast<int>(text_.length() - text->ToString().length() - candidate.length());
     // Check for extra numbers at the end.
     reg_exps_->capture_up_to_second_number_start_pattern_->
         PartialMatch(candidate, &candidate);
@@ -668,7 +668,7 @@ bool PhoneNumberMatcher::Find(int index, PhoneNumberMatch* match) {
       return true;
     }
 
-    index = start + candidate.length();
+    index = static_cast<int>(start + candidate.length());
     --max_tries_;
   }
   return false;
@@ -822,9 +822,9 @@ bool PhoneNumberMatcher::AllNumberGroupsAreExactlyPresent(
   }
 
   // Set this to the last group, skipping it if the number has an extension.
-  int candidate_number_group_index =
+  int candidate_number_group_index = static_cast<int>(
       phone_number.has_extension() ? candidate_groups.size() - 2
-                                   : candidate_groups.size() - 1;
+                                   : candidate_groups.size() - 1);
   // First we check if the national significant number is formatted as a block.
   // We use find and not equals, since the national significant number may be
   // present with a prefix such as a national number prefix, or the country code
@@ -840,7 +840,7 @@ bool PhoneNumberMatcher::AllNumberGroupsAreExactlyPresent(
   // Starting from the end, go through in reverse, excluding the first group,
   // and check the candidate and number groups are the same.
   for (int formatted_number_group_index =
-           (formatted_number_groups.size() - 1);
+           static_cast<int>(formatted_number_groups.size() - 1);
        formatted_number_group_index > 0 &&
        candidate_number_group_index >= 0;
        --formatted_number_group_index, --candidate_number_group_index) {

--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -328,7 +328,7 @@ void NormalizeHelper(const std::map<char32, char>& normalization_replacements,
                      string* number) {
   DCHECK(number);
   UnicodeText number_as_unicode;
-  number_as_unicode.PointToUTF8(number->data(), number->size());
+  number_as_unicode.PointToUTF8(number->data(), static_cast<int>(number->size()));
   string normalized_number;
   char unicode_char[5];
   for (UnicodeText::const_iterator it = number_as_unicode.begin();
@@ -450,7 +450,7 @@ PhoneNumberUtil::ValidationResult TestNumberLength(
     return PhoneNumberUtil::INVALID_LENGTH;
   }
 
-  int actual_length = number.length();
+  int actual_length = static_cast<int>(number.length());
   // This is safe because there is never an overlap beween the possible lengths
   // and the local-only lengths; this is checked at build time.
   if (std::find(local_lengths.begin(), local_lengths.end(), actual_length) !=
@@ -970,7 +970,7 @@ bool PhoneNumberUtil::ContainsOnlyValidDigits(const string& s) const {
 void PhoneNumberUtil::TrimUnwantedEndChars(string* number) const {
   DCHECK(number);
   UnicodeText number_as_unicode;
-  number_as_unicode.PointToUTF8(number->data(), number->size());
+  number_as_unicode.PointToUTF8(number->data(), static_cast<int>(number->size()));
   char current_char[5];
   int len;
   UnicodeText::const_reverse_iterator reverse_it(number_as_unicode.end());
@@ -2142,7 +2142,7 @@ void PhoneNumberUtil::BuildNationalNumberForParsing(
     // case, we append everything from the beginning.
     size_t index_of_rfc_prefix = number_to_parse.find(kRfc3966Prefix);
     int index_of_national_number = (index_of_rfc_prefix != string::npos) ?
-        index_of_rfc_prefix + strlen(kRfc3966Prefix) : 0;
+        static_cast<int>(index_of_rfc_prefix + strlen(kRfc3966Prefix)) : 0;
     StrAppend(
         national_number,
         number_to_parse.substr(
@@ -2302,7 +2302,7 @@ void PhoneNumberUtil::ExtractPossibleNumber(const string& number,
   DCHECK(extracted_number);
 
   UnicodeText number_as_unicode;
-  number_as_unicode.PointToUTF8(number.data(), number.size());
+  number_as_unicode.PointToUTF8(number.data(), static_cast<int>(number.size()));
   char current_char[5];
   int len;
   UnicodeText::const_iterator it;
@@ -2470,7 +2470,7 @@ void PhoneNumberUtil::SetItalianLeadingZerosForPhoneNumber(
       number_of_leading_zeros++;
     }
     if (number_of_leading_zeros != 1) {
-      phone_number->set_number_of_leading_zeros(number_of_leading_zeros);
+      phone_number->set_number_of_leading_zeros(static_cast<int32_t>(number_of_leading_zeros));
     }
   }
 }
@@ -2481,7 +2481,7 @@ bool PhoneNumberUtil::IsNumberMatchingDesc(
   // avoid checking the validation pattern if they don't match. If they are
   // absent, this means they match the general description, which we have
   // already checked before checking a specific number type.
-  int actual_length = national_number.length();
+  int actual_length = static_cast<int>(national_number.length());
   if (number_desc.possible_length_size() > 0 &&
       std::find(number_desc.possible_length().begin(),
                 number_desc.possible_length().end(),
@@ -2639,10 +2639,10 @@ int PhoneNumberUtil::GetLengthOfNationalDestinationCode(
     string mobile_token;
     GetCountryMobileToken(number.country_code(), &mobile_token);
     if (!mobile_token.empty()) {
-      return third_group.size() + mobile_token.size();
+      return static_cast<int>(third_group.size() + mobile_token.size());
     }
   }
-  return ndc.size();
+  return static_cast<int>(ndc.size());
 }
 
 void PhoneNumberUtil::GetCountryMobileToken(int country_calling_code,

--- a/cpp/src/phonenumbers/regexp_adapter_icu.cc
+++ b/cpp/src/phonenumbers/regexp_adapter_icu.cc
@@ -55,7 +55,7 @@ string UnicodeStringToUtf8String(const UnicodeString& source) {
 UnicodeString Utf8StringToUnicodeString(const string& source) {
   // Note that we don't use icu::StringPiece(const string&).
   return UnicodeString::fromUTF8(
-      icu::StringPiece(source.c_str(), source.size()));
+      icu::StringPiece(source.c_str(), static_cast<int>(source.size())));
 }
 
 }  // namespace
@@ -145,7 +145,7 @@ class IcuRegExp : public RegExp {
     for (size_t i = 0; i < arraysize(matched_strings); ++i) {
       if (matched_strings[i]) {
         // Groups are counted from 1 rather than 0.
-        const int group_index = i + 1;
+        const int group_index = static_cast<int>(i + 1);
         if (group_index > matcher->groupCount()) {
           return false;
         }

--- a/cpp/src/phonenumbers/stringutil.cc
+++ b/cpp/src/phonenumbers/stringutil.cc
@@ -163,7 +163,7 @@ int GlobalReplaceSubstring(const string& substring,
   int pos = 0;
   for (size_t match_pos = s->find(substring.data(), pos, substring.length());
        match_pos != string::npos;
-       pos = match_pos + substring.length(),
+       pos = static_cast<int>(match_pos + substring.length()),
           match_pos = s->find(substring.data(), pos, substring.length())) {
     ++num_replacements;
     // Append the original content before the match.

--- a/cpp/src/phonenumbers/unicodestring.h
+++ b/cpp/src/phonenumbers/unicodestring.h
@@ -34,7 +34,7 @@ class UnicodeString {
 
   // Constructs a new unicode string copying the provided C string.
   explicit UnicodeString(const char* utf8)
-      : text_(UTF8ToUnicodeText(utf8, std::strlen(utf8))),
+      : text_(UTF8ToUnicodeText(utf8, static_cast<int>(std::strlen(utf8)))),
         cached_index_(-1) {}
 
   // Constructs a new unicode string containing the provided codepoint.
@@ -89,7 +89,7 @@ class UnicodeString {
   // Copies the provided C string.
   inline void setTo(const char* s, size_t len) {
     invalidateCachedIndex();
-    text_.CopyUTF8(s, len);
+    text_.CopyUTF8(s, static_cast<int>(len));
   }
 
   // Returns the substring located at [ start, start + length - 1 ] without

--- a/cpp/src/phonenumbers/utf/unicodetext.cc
+++ b/cpp/src/phonenumbers/utf/unicodetext.cc
@@ -73,7 +73,7 @@ static int ConvertToInterchangeValid(char* start, int len) {
   char* out = start;
   char* const end = start + len;
   while (start < end) {
-    int good = UniLib::SpanInterchangeValid(start, end - start);
+    int good = UniLib::SpanInterchangeValid(start, static_cast<int>(end - start));
     if (good > 0) {
       if (out != start) {
         memmove(out, start, good);
@@ -87,7 +87,7 @@ static int ConvertToInterchangeValid(char* start, int len) {
     // Is the current string invalid UTF8 or just non-interchange UTF8?
     Rune rune;
     int n;
-    if (isvalidcharntorune(start, end - start, &rune, &n)) {
+    if (isvalidcharntorune(start, static_cast<int>(end - start), &rune, &n)) {
       // structurally valid UTF8, but not interchange valid
       start += n;  // Skip over the whole character.
     } else {  // bad UTF8
@@ -95,7 +95,7 @@ static int ConvertToInterchangeValid(char* start, int len) {
     }
     *out++ = ' ';
   }
-  return out - in;
+  return static_cast<int>(out - in);
 }
 
 
@@ -204,7 +204,7 @@ UnicodeText::UnicodeText(const UnicodeText& src) {
 UnicodeText::UnicodeText(const UnicodeText::const_iterator& first,
                          const UnicodeText::const_iterator& last) {
   assert(first <= last && "Incompatible iterators");
-  repr_.append(first.it_, last.it_ - first.it_);
+  repr_.append(first.it_, static_cast<int>(last.it_ - first.it_));
 }
 
 string UnicodeText::UTF8Substring(const const_iterator& first,
@@ -290,7 +290,7 @@ UnicodeText& UnicodeText::PointTo(const UnicodeText& src) {
 UnicodeText& UnicodeText::PointTo(const const_iterator &first,
                                   const const_iterator &last) {
   assert(first <= last && " Incompatible iterators");
-  repr_.PointTo(first.utf8_data(), last.utf8_data() - first.utf8_data());
+  repr_.PointTo(first.utf8_data(), static_cast<int>(last.utf8_data() - first.utf8_data()));
   return *this;
 }
 
@@ -304,7 +304,7 @@ UnicodeText& UnicodeText::append(const UnicodeText& u) {
 UnicodeText& UnicodeText::append(const const_iterator& first,
                                  const const_iterator& last) {
   assert(first <= last && "Incompatible iterators");
-  repr_.append(first.it_, last.it_ - first.it_);
+  repr_.append(first.it_, static_cast<int>(last.it_ - first.it_));
   return *this;
 }
 

--- a/cpp/src/phonenumbers/utf/unicodetext.h
+++ b/cpp/src/phonenumbers/utf/unicodetext.h
@@ -439,7 +439,7 @@ inline UnicodeText UTF8ToUnicodeText(const char* utf8_buf, int len,
 }
 
 inline UnicodeText UTF8ToUnicodeText(const string& utf_string, bool do_copy) {
-  return UTF8ToUnicodeText(utf_string.data(), utf_string.size(), do_copy);
+  return UTF8ToUnicodeText(utf_string.data(), static_cast<int>(utf_string.size()), do_copy);
 }
 
 inline UnicodeText UTF8ToUnicodeText(const char* utf8_buf, int len) {

--- a/cpp/src/phonenumbers/utf/unilib.cc
+++ b/cpp/src/phonenumbers/utf/unilib.cc
@@ -50,7 +50,7 @@ int SpanInterchangeValid(const char* begin, int byte_length) {
   const char* p = begin;
   const char* end = begin + byte_length;
   while (p < end) {
-    int bytes_consumed = charntorune(&rune, p, end - p);
+    int bytes_consumed = charntorune(&rune, p, static_cast<int>(end - p));
     // We want to accept Runeerror == U+FFFD as a valid char, but it is used
     // by chartorune to indicate error. Luckily, the real codepoint is size 3
     // while errors return bytes_consumed <= 1.
@@ -60,7 +60,7 @@ int SpanInterchangeValid(const char* begin, int byte_length) {
     }
     p += bytes_consumed;
   }
-  return p - begin;
+  return static_cast<int>(p - begin);
 }
 
 }  // namespace UniLib

--- a/cpp/src/phonenumbers/utf/unilib.h
+++ b/cpp/src/phonenumbers/utf/unilib.h
@@ -79,7 +79,7 @@ inline bool IsTrailByte(char x) {
 //  interchange valid UTF-8
 int SpanInterchangeValid(const char* src, int byte_length);
 inline int SpanInterchangeValid(const std::string& src) {
-  return SpanInterchangeValid(src.data(), src.size());
+  return SpanInterchangeValid(src.data(), static_cast<int>(src.size()));
 }
 
 // Returns true if the source is all interchange valid UTF-8
@@ -89,7 +89,7 @@ inline bool IsInterchangeValid(const char* src, int byte_length) {
   return (byte_length == SpanInterchangeValid(src, byte_length));
 }
 inline bool IsInterchangeValid(const std::string& src) {
-  return IsInterchangeValid(src.data(), src.size());
+  return IsInterchangeValid(src.data(), static_cast<int>(src.size()));
 }
 
 }  // namespace UniLib


### PR DESCRIPTION
In visual studio 2019 x64 target, size_t are 64 bits and int are 32 bits

This commit cast some length of string from size_t to int to fix warnings