### PR TITLE
Fix geocoding C++ build when static libraries are off.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -480,7 +480,9 @@ if (${BUILD_GEOCODER} STREQUAL "ON")
   list (APPEND GEOCODER_DEPS ${COMMON_DEPS})
   # Note that the subset of base/ on which the geocoder relies is implemented
   # on top of Boost header-only libraries (e.g. scoped_ptr.hpp).
-  target_link_libraries (geocoding ${LIBRARY_DEPS})
+  if (${BUILD_STATIC_LIB} STREQUAL "ON")
+    target_link_libraries (geocoding ${LIBRARY_DEPS})
+  endif ()
   target_link_libraries (geocoding-shared ${LIBRARY_DEPS})
 endif ()
 
@@ -647,7 +649,9 @@ if (BUILD_SHARED_LIB)
 endif ()
 
 if (${BUILD_GEOCODER} STREQUAL "ON")
-  install (TARGETS geocoding LIBRARY DESTINATION ${LIBDIR} ARCHIVE DESTINATION ${LIBDIR})
+  if (${BUILD_STATIC_LIB} STREQUAL "ON")
+    install (TARGETS geocoding LIBRARY DESTINATION ${LIBDIR} ARCHIVE DESTINATION ${LIBDIR})
+  endif ()
   install (TARGETS geocoding-shared LIBRARY DESTINATION ${LIBDIR} ARCHIVE
            DESTINATION ${LIBDIR})
 endif ()
@@ -659,7 +663,11 @@ if (${BUILD_GEOCODER} STREQUAL "ON")
     geocoding_test_program
     "test/phonenumbers/geocoding/geocoding_test_program.cc"
   )
-  target_link_libraries (geocoding_test_program geocoding phonenumber)
+  if (${BUILD_STATIC_LIB} STREQUAL "ON")
+    target_link_libraries (geocoding_test_program geocoding phonenumber)
+  else ()
+    target_link_libraries (geocoding_test_program geocoding-shared phonenumber-shared)
+  endif ()
 endif ()
 
 # Build an RPM


### PR DESCRIPTION
I'm using the following CMake command to configure my libphonenumber build:

```
cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_GEOCODER=ON -DUSE_ALTERNATE_FORMATS=OFF -DUSE_ICU_REGEXP=ON -DUSE_LITE_METADATA=ON -DUSE_RE2=OFF -DBUILD_STATIC_LIB=OFF ..
```

This patch fixes the build with the above options. Without this patch CMake can't configure and build libphonenumber when geocoding is enabled but static library build is off.