### PR TITLE
Fix the unit test case issues in DOS/Windows platform by picking the new line char dynamically.

### DIFF
--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/AltFormatsSchemaTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/AltFormatsSchemaTest.java
@@ -17,7 +17,6 @@ package com.google.i18n.phonenumbers.metadata.model;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -26,6 +25,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -98,14 +98,23 @@ public class AltFormatsSchemaTest {
     try (StringWriter out = new StringWriter()) {
       AltFormatsSchema.exportCsv(out, Arrays.asList(altFormats));
       // Ignore trailing empty lines.
-      return Splitter.on('\n').splitToList(CharMatcher.is('\n').trimTrailingFrom(out.toString()));
+      return Splitter.on(getNewLineChar()).splitToList(out.toString().trim());
     }
   }
 
   private static ImmutableList<AltFormatSpec> importCsv(String... lines)
       throws IOException {
     // Add a trailing newline, since that's what we expect in the real CSV files.
-    StringReader file = new StringReader(Joiner.on('\n').join(lines) + "\n");
+    StringReader file =
+        new StringReader(Joiner.on(getNewLineChar()).join(lines) + getNewLineChar());
     return AltFormatsSchema.importAltFormats(file);
   }
+
+  private static String getNewLineChar() {
+    Optional<String> newLineChar = Optional.ofNullable(System.getProperty("line.separator"));
+    // If not present, we would like to fall-back to Unix's line-end character as that is more
+    // common.
+    return newLineChar.isPresent() ? newLineChar.get() : "\n";
+  }
 }
+

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/AltFormatsSchemaTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/AltFormatsSchemaTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.i18n.phonenumbers.metadata.model;
 
+import static com.google.common.base.StandardSystemProperty.LINE_SEPARATOR;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.base.Joiner;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/AltFormatsSchemaTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/AltFormatsSchemaTest.java
@@ -26,7 +26,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/AltFormatsSchemaTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/AltFormatsSchemaTest.java
@@ -34,7 +34,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class AltFormatsSchemaTest {
 
-  private static final String NEW_LINE_CHAR = getNewLineChar();
+  private static final String NEW_LINE = LINE_SEPARATOR.value();
 
   @Test
   public void testSimple_export() throws IOException {
@@ -101,22 +101,15 @@ public class AltFormatsSchemaTest {
     try (StringWriter out = new StringWriter()) {
       AltFormatsSchema.exportCsv(out, Arrays.asList(altFormats));
       // Ignore trailing empty lines.
-      return Splitter.on(NEW_LINE_CHAR).splitToList(out.toString().trim());
+      return Splitter.on(NEW_LINE).omitEmptyStrings().splitToList(out.toString());
     }
   }
 
   private static ImmutableList<AltFormatSpec> importCsv(String... lines)
       throws IOException {
     // Add a trailing newline, since that's what we expect in the real CSV files.
-    StringReader file = new StringReader(Joiner.on(NEW_LINE_CHAR).join(lines) + NEW_LINE_CHAR);
+    StringReader file = new StringReader(Joiner.on(NEW_LINE).join(lines) + NEW_LINE);
     return AltFormatsSchema.importAltFormats(file);
-  }
-
-  private static String getNewLineChar() {
-    Optional<String> newLineChar = Optional.ofNullable(LINE_SEPARATOR.value());
-    // If not present, we would like to fall-back to Unix's line-end character as that is more
-    // common.
-    return newLineChar.orElse("\n");
   }
 }
 

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/AltFormatsSchemaTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/AltFormatsSchemaTest.java
@@ -33,6 +33,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class AltFormatsSchemaTest {
 
+  private static final String NEW_LINE_CHAR = getNewLineChar();
+
   @Test
   public void testSimple_export() throws IOException {
     assertThat(
@@ -98,23 +100,22 @@ public class AltFormatsSchemaTest {
     try (StringWriter out = new StringWriter()) {
       AltFormatsSchema.exportCsv(out, Arrays.asList(altFormats));
       // Ignore trailing empty lines.
-      return Splitter.on(getNewLineChar()).splitToList(out.toString().trim());
+      return Splitter.on(NEW_LINE_CHAR).splitToList(out.toString().trim());
     }
   }
 
   private static ImmutableList<AltFormatSpec> importCsv(String... lines)
       throws IOException {
     // Add a trailing newline, since that's what we expect in the real CSV files.
-    StringReader file =
-        new StringReader(Joiner.on(getNewLineChar()).join(lines) + getNewLineChar());
+    StringReader file = new StringReader(Joiner.on(NEW_LINE_CHAR).join(lines) + NEW_LINE_CHAR);
     return AltFormatsSchema.importAltFormats(file);
   }
 
   private static String getNewLineChar() {
-    Optional<String> newLineChar = Optional.ofNullable(System.getProperty("line.separator"));
+    Optional<String> newLineChar = Optional.ofNullable(LINE_SEPARATOR.value());
     // If not present, we would like to fall-back to Unix's line-end character as that is more
     // common.
-    return newLineChar.isPresent() ? newLineChar.get() : "\n";
+    return newLineChar.orElse("\n");
   }
 }
 

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/CommentsSchemaTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/CommentsSchemaTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.i18n.phonenumbers.metadata.model;
 
+import static com.google.common.base.StandardSystemProperty.LINE_SEPARATOR;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.i18n.phonenumbers.metadata.model.NumberingScheme.Comment.anchor;
 import static com.google.i18n.phonenumbers.metadata.proto.Types.XmlNumberType.XML_FIXED_LINE;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/CommentsSchemaTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/CommentsSchemaTest.java
@@ -40,7 +40,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CommentsSchemaTest {
 
-  private static final String NEW_LINE_CHAR = getNewLineChar();
+  private static final String NEW_LINE = LINE_SEPARATOR.value();
 
   private static final PhoneRegion REGION_US = PhoneRegion.of("US");
   private static final PhoneRegion REGION_CA = PhoneRegion.of("CA");
@@ -147,22 +147,15 @@ public class CommentsSchemaTest {
     try (StringWriter out = new StringWriter()) {
       CommentsSchema.exportCsv(out, Arrays.asList(comments));
       // Ignore trailing empty lines.
-      return Splitter.on(NEW_LINE_CHAR).splitToList(out.toString().trim());
+      return Splitter.on(NEW_LINE).omitEmptyStrings().splitToList(out.toString());
     }
   }
 
   private static ImmutableList<Comment> importCsv(String... lines)
       throws IOException {
     // Add a trailing newline, since that's what we expect in the real CSV files.
-    StringReader file = new StringReader(Joiner.on(NEW_LINE_CHAR).join(lines) + NEW_LINE_CHAR);
+    StringReader file = new StringReader(Joiner.on(NEW_LINE).join(lines) + NEW_LINE);
     return CommentsSchema.importComments(file);
-  }
-
-  private static String getNewLineChar() {
-    Optional<String> newLineChar = Optional.ofNullable(LINE_SEPARATOR.value());
-    // If not present, we would like to fall-back to Unix's line-end character as that is more
-    // common.
-    return newLineChar.orElse("\n");
   }
 }
 

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/CommentsSchemaTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/CommentsSchemaTest.java
@@ -38,6 +38,9 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class CommentsSchemaTest {
+
+  private static final String NEW_LINE_CHAR = getNewLineChar();
+
   private static final PhoneRegion REGION_US = PhoneRegion.of("US");
   private static final PhoneRegion REGION_CA = PhoneRegion.of("CA");
 
@@ -143,23 +146,22 @@ public class CommentsSchemaTest {
     try (StringWriter out = new StringWriter()) {
       CommentsSchema.exportCsv(out, Arrays.asList(comments));
       // Ignore trailing empty lines.
-      return Splitter.on(getNewLineChar()).splitToList(out.toString().trim());
+      return Splitter.on(NEW_LINE_CHAR).splitToList(out.toString().trim());
     }
   }
 
   private static ImmutableList<Comment> importCsv(String... lines)
       throws IOException {
     // Add a trailing newline, since that's what we expect in the real CSV files.
-    StringReader file =
-        new StringReader(Joiner.on(getNewLineChar()).join(lines) + getNewLineChar());
+    StringReader file = new StringReader(Joiner.on(NEW_LINE_CHAR).join(lines) + NEW_LINE_CHAR);
     return CommentsSchema.importComments(file);
   }
 
   private static String getNewLineChar() {
-    Optional<String> newLineChar = Optional.ofNullable(System.getProperty("line.separator"));
+    Optional<String> newLineChar = Optional.ofNullable(LINE_SEPARATOR.value());
     // If not present, we would like to fall-back to Unix's line-end character as that is more
     // common.
-    return newLineChar.isPresent() ? newLineChar.get() : "\n";
+    return newLineChar.orElse("\n");
   }
 }
 

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/CommentsSchemaTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/CommentsSchemaTest.java
@@ -32,7 +32,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/CommentsSchemaTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/model/CommentsSchemaTest.java
@@ -20,7 +20,6 @@ import static com.google.i18n.phonenumbers.metadata.model.NumberingScheme.Commen
 import static com.google.i18n.phonenumbers.metadata.proto.Types.XmlNumberType.XML_FIXED_LINE;
 import static com.google.i18n.phonenumbers.metadata.proto.Types.XmlNumberType.XML_MOBILE;
 
-import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -32,6 +31,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -143,14 +143,23 @@ public class CommentsSchemaTest {
     try (StringWriter out = new StringWriter()) {
       CommentsSchema.exportCsv(out, Arrays.asList(comments));
       // Ignore trailing empty lines.
-      return Splitter.on('\n').splitToList(CharMatcher.is('\n').trimTrailingFrom(out.toString()));
+      return Splitter.on(getNewLineChar()).splitToList(out.toString().trim());
     }
   }
 
   private static ImmutableList<Comment> importCsv(String... lines)
       throws IOException {
     // Add a trailing newline, since that's what we expect in the real CSV files.
-    StringReader file = new StringReader(Joiner.on('\n').join(lines) + "\n");
+    StringReader file =
+        new StringReader(Joiner.on(getNewLineChar()).join(lines) + getNewLineChar());
     return CommentsSchema.importComments(file);
   }
+
+  private static String getNewLineChar() {
+    Optional<String> newLineChar = Optional.ofNullable(System.getProperty("line.separator"));
+    // If not present, we would like to fall-back to Unix's line-end character as that is more
+    // common.
+    return newLineChar.isPresent() ? newLineChar.get() : "\n";
+  }
 }
+

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/CsvTableTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/CsvTableTest.java
@@ -65,7 +65,7 @@ public class CsvTableTest {
   private static final Column<Boolean> REGION_CA = REGIONS.getColumn(PhoneRegion.of("CA"));
   private static final Column<Boolean> REGION_US = REGIONS.getColumn(PhoneRegion.of("US"));
 
-  private static final String NEW_LINE_CHAR = getNewLineChar();
+  private static final String NEW_LINE = LINE_SEPARATOR.value();
 
   @Test
   public void testRangeTableExport() throws IOException {
@@ -94,7 +94,6 @@ public class CsvTableTest {
     table.put(PhoneRegion.of("US"), ValidNumberType.PREMIUM_RATE, DigitSequence.of("945123456"));
     table.put(PhoneRegion.of("CA"), ValidNumberType.MOBILE, DigitSequence.of("555123456"));
     // Ordering is well defined in the CSV output.
-    // TODO: Consider making columns able to identify if their values need CSV escaping.
     CsvTable<ExampleNumberKey> csv = ExamplesTableSchema.toCsv(table);
     assertCsv(csv,
         "Region ; Type         ; Number",
@@ -267,20 +266,13 @@ public class CsvTableTest {
   }
 
   private static String join(String... lines) {
-    return String.join(NEW_LINE_CHAR, lines) + NEW_LINE_CHAR;
+    return String.join(NEW_LINE, lines) + NEW_LINE;
   }
 
   private static RangeKey key(String spec, Integer... lengths) {
     RangeSpecification prefix =
         spec.isEmpty() ? RangeSpecification.empty() : RangeSpecification.parse(spec);
     return RangeKey.create(prefix, ImmutableSet.copyOf(lengths));
-  }
-
-  private static String getNewLineChar() {
-    Optional<String> newLineChar = Optional.ofNullable(LINE_SEPARATOR.value());
-    // If not present, we would like to fall-back to Unix's line-end character as that is more
-    // common.
-    return newLineChar.orElse("\n");
   }
 }
 

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/CsvTableTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/CsvTableTest.java
@@ -16,6 +16,7 @@
 package com.google.i18n.phonenumbers.metadata.table;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.StandardSystemProperty.LINE_SEPARATOR;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.i18n.phonenumbers.metadata.model.RangesTableSchema.AREA_CODE_LENGTH;
 import static com.google.i18n.phonenumbers.metadata.model.RangesTableSchema.COMMENT;

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/CsvTableTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/CsvTableTest.java
@@ -64,6 +64,8 @@ public class CsvTableTest {
   private static final Column<Boolean> REGION_CA = REGIONS.getColumn(PhoneRegion.of("CA"));
   private static final Column<Boolean> REGION_US = REGIONS.getColumn(PhoneRegion.of("US"));
 
+  private static final String NEW_LINE_CHAR = getNewLineChar();
+
   @Test
   public void testRangeTableExport() throws IOException {
     ImmutableList<Column<?>> columns =
@@ -264,7 +266,7 @@ public class CsvTableTest {
   }
 
   private static String join(String... lines) {
-    return String.join(getNewLineChar(), lines) + getNewLineChar();
+    return String.join(NEW_LINE_CHAR, lines) + NEW_LINE_CHAR;
   }
 
   private static RangeKey key(String spec, Integer... lengths) {
@@ -274,10 +276,10 @@ public class CsvTableTest {
   }
 
   private static String getNewLineChar() {
-    Optional<String> newLineChar = Optional.ofNullable(System.getProperty("line.separator"));
+    Optional<String> newLineChar = Optional.ofNullable(LINE_SEPARATOR.value());
     // If not present, we would like to fall-back to Unix's line-end character as that is more
     // common.
-    return newLineChar.isPresent() ? newLineChar.get() : "\n";
+    return newLineChar.orElse("\n");
   }
 }
 

--- a/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/CsvTableTest.java
+++ b/metadata/src/test/java/com/google/i18n/phonenumbers/metadata/table/CsvTableTest.java
@@ -264,7 +264,7 @@ public class CsvTableTest {
   }
 
   private static String join(String... lines) {
-    return String.join("\n", lines) + "\n";
+    return String.join(getNewLineChar(), lines) + getNewLineChar();
   }
 
   private static RangeKey key(String spec, Integer... lengths) {
@@ -272,4 +272,12 @@ public class CsvTableTest {
         spec.isEmpty() ? RangeSpecification.empty() : RangeSpecification.parse(spec);
     return RangeKey.create(prefix, ImmutableSet.copyOf(lengths));
   }
+
+  private static String getNewLineChar() {
+    Optional<String> newLineChar = Optional.ofNullable(System.getProperty("line.separator"));
+    // If not present, we would like to fall-back to Unix's line-end character as that is more
+    // common.
+    return newLineChar.isPresent() ? newLineChar.get() : "\n";
+  }
 }
+


### PR DESCRIPTION
As the new line characters are not well trimmed or joined, the results are not as expected in export* API unit tests.
Eg:
```
missing (2)   : Region ; Label          ; Comment, US     ; XML_FIXED_LINE ; "Hello World"
, US     ; XML_FIXED_LINE ; "Hello World" Comment
---
expected      : [Region ; Label          ; Comment, US     ; XML_FIXED_LINE ; "Hello World"]
] US     ; XML_FIXED_LINE ; "Hello World"; Comment
        at com.google.i18n.phonenumbers.metadata.model.CommentsSchemaTest.testSimple_export(CommentsSchemaTest.java:55)
```

Found these unit test issues when buidling the Windows machine. Some notes in cl/346717586.
