### PR TITLE
Fix building as dependency with add_subdirectory()

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -175,7 +175,7 @@ if (${USE_STD_MAP} STREQUAL "OFF")
 endif ()
 
 # Add protoc (Protocol Buffers compiler) target.
-set (RESOURCES_DIR "${CMAKE_SOURCE_DIR}/../resources")
+set (RESOURCES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../resources")
 
 set (
   PROTOBUF_SOURCES "${RESOURCES_DIR}/phonemetadata.proto"
@@ -183,14 +183,14 @@ set (
 )
 
 set (
-  PROTOBUF_OUTPUT "${CMAKE_SOURCE_DIR}/src/phonenumbers/phonemetadata.pb.cc"
-                  "${CMAKE_SOURCE_DIR}/src/phonenumbers/phonemetadata.pb.h"
-                  "${CMAKE_SOURCE_DIR}/src/phonenumbers/phonenumber.pb.cc"
-                  "${CMAKE_SOURCE_DIR}/src/phonenumbers/phonenumber.pb.h"
+  PROTOBUF_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/phonenumbers/phonemetadata.pb.cc"
+                  "${CMAKE_CURRENT_SOURCE_DIR}/src/phonenumbers/phonemetadata.pb.h"
+                  "${CMAKE_CURRENT_SOURCE_DIR}/src/phonenumbers/phonenumber.pb.cc"
+                  "${CMAKE_CURRENT_SOURCE_DIR}/src/phonenumbers/phonenumber.pb.h"
 )
 
 add_custom_command (
-  COMMAND ${PROTOC_BIN} --cpp_out=${CMAKE_SOURCE_DIR}/src/phonenumbers/
+  COMMAND ${PROTOC_BIN} --cpp_out=${CMAKE_CURRENT_SOURCE_DIR}/src/phonenumbers/
     --proto_path=${RESOURCES_DIR} ${PROTOBUF_SOURCES}
 
   OUTPUT ${PROTOBUF_OUTPUT}
@@ -200,13 +200,13 @@ add_custom_command (
 if (${BUILD_GEOCODER} STREQUAL "ON")
   # Geocoding data cpp file generation
   set (TOOLS_DIR "${CMAKE_CURRENT_BINARY_DIR}/tools")
-  add_subdirectory("${CMAKE_SOURCE_DIR}/../tools/cpp" "${TOOLS_DIR}")
+  add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../tools/cpp" "${TOOLS_DIR}")
 
   set (GEOCODING_DIR "${RESOURCES_DIR}/geocoding")
   file (GLOB_RECURSE GEOCODING_SOURCES "${GEOCODING_DIR}/*.txt")
 
   set (GEOCODING_DATA_OUTPUT
-    "${CMAKE_SOURCE_DIR}/src/phonenumbers/geocoding/geocoding_data.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/phonenumbers/geocoding/geocoding_data.cc"
   )
 
   add_custom_command (
@@ -290,17 +290,17 @@ function (add_metadata_gen_target TARGET_NAME
                                   XML_FILE
                                   METADATA_TYPE
                                   METADATA_HEADER)
-  set (METADATA_SOURCE_DIR "${CMAKE_SOURCE_DIR}/src/phonenumbers")
+  set (METADATA_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/phonenumbers")
   set (GEN_OUTPUT "${METADATA_SOURCE_DIR}/${METADATA_TYPE}.cc"
                   "${METADATA_SOURCE_DIR}/${METADATA_HEADER}.h")
-  set (JAR_PATH "${CMAKE_SOURCE_DIR}/../tools/java/cpp-build/target")
+  set (JAR_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../tools/java/cpp-build/target")
   set (JAR_PATH "${JAR_PATH}/cpp-build-1.0-SNAPSHOT-jar-with-dependencies.jar")
 
   if (${REGENERATE_METADATA} STREQUAL "ON")
     add_custom_command (
       COMMAND ${JAVA_BIN} -jar
         ${JAR_PATH} BuildMetadataCppFromXml ${XML_FILE}
-        ${CMAKE_SOURCE_DIR}/src/phonenumbers ${METADATA_TYPE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/phonenumbers ${METADATA_TYPE}
 
       OUTPUT ${GEN_OUTPUT}
       DEPENDS ${XML_FILE}
@@ -309,7 +309,7 @@ function (add_metadata_gen_target TARGET_NAME
     add_custom_command (
       COMMAND echo "skip metadata generation from"
         ${XML_FILE} "to"
-        ${CMAKE_SOURCE_DIR}/src/phonenumbers ${METADATA_TYPE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/phonenumbers ${METADATA_TYPE}
 
       OUTPUT ${GEN_OUTPUT}
       DEPENDS ${XML_FILE}
@@ -504,7 +504,7 @@ if (${BUILD_GEOCODER} STREQUAL "ON")
   file (GLOB_RECURSE GEOCODING_TEST_SOURCES "${GEOCODING_TEST_DIR}/*.txt")
 
   set (GEOCODING_TEST_DATA_OUTPUT
-    "${CMAKE_SOURCE_DIR}/test/phonenumbers/geocoding/geocoding_test_data.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/phonenumbers/geocoding/geocoding_test_data.cc"
   )
 
   add_custom_command (


### PR DESCRIPTION
- When building as a dependency using cmake's add_subdirectory() use the
  current source directory instead of the top level source tree.

Previously it was not possible to use libphonenumber in such a way, especially when linking statically.