### PR TITLE
Add missing include

### DIFF
--- a/cpp/src/phonenumbers/phonenumbermatcher.cc
+++ b/cpp/src/phonenumbers/phonenumbermatcher.cc
@@ -29,6 +29,7 @@
 #include <stddef.h>
 #include <limits>
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
Needed for std::unique_ptr. Building was broken previously on Ubuntu 18.04.