### PR TITLE
warning fix unused-parameter

### DIFF
--- a/cpp/src/phonenumbers/base/memory/scoped_ptr.h
+++ b/cpp/src/phonenumbers/base/memory/scoped_ptr.h
@@ -33,7 +33,7 @@ namespace phonenumbers {
 template <class T>
 struct DefaultDeleter {
   DefaultDeleter() {}
-  template <typename U> DefaultDeleter(const DefaultDeleter<U>& other) {
+  template <typename U> DefaultDeleter(const DefaultDeleter<U>& /*other*/) {
     // IMPLEMENTATION NOTE: C++11 20.7.1.1.2p2 only provides this constructor
     // if U* is implicitly convertible to T* and U is not an array type.
     //


### PR DESCRIPTION
This PR contain a very simple fix for a unused parameter warning