### PR TITLE
Fix the JS demo compilation with the latest Closure compiler

### DIFF
--- a/javascript/build.xml
+++ b/javascript/build.xml
@@ -47,7 +47,7 @@
         <arg line='-f "--jscomp_error=misplacedTypeAnnotation"' />
         <arg line='-f "--jscomp_error=missingProperties"' />
         <arg line='-f "--jscomp_error=missingRequire"' />
-        <arg line='-f "--jscomp_error=strictMissingRequire"' />
+        <arg line='-f "--jscomp_error=missingRequire"' />
         <arg line='-f "--jscomp_error=nonStandardJsDocs"' />
         <arg line='-f "--jscomp_error=strictModuleDepCheck"' />
         <arg line='-f "--jscomp_error=suspiciousCode"' />

--- a/javascript/i18n/phonenumbers/phonemetadata.pb.js
+++ b/javascript/i18n/phonenumbers/phonemetadata.pb.js
@@ -27,6 +27,7 @@ goog.provide('i18n.phonenumbers.PhoneMetadata');
 goog.provide('i18n.phonenumbers.PhoneMetadataCollection');
 
 goog.require('goog.proto2.Message');
+goog.require('goog.proto2.Descriptor');
 
 
 

--- a/javascript/i18n/phonenumbers/phonenumber.pb.js
+++ b/javascript/i18n/phonenumbers/phonenumber.pb.js
@@ -26,6 +26,7 @@ goog.provide('i18n.phonenumbers.PhoneNumber');
 goog.provide('i18n.phonenumbers.PhoneNumber.CountryCodeSource');
 
 goog.require('goog.proto2.Message');
+goog.require('goog.proto2.Descriptor');
 
 
 


### PR DESCRIPTION
I tried building the JS demo using the latest release of the Google Closure compiler. It failed with the following error:
```
$ ant -f javascript/build.xml compile-demo
Buildfile: /home/senya/libphonenumber-tools/libphonenumber/javascript/build.xml

compile-demo:
     [exec] /home/senya/libphonenumber-tools/libphonenumber/javascript/../../closure-library/closure/bin/build/closurebuilder.py: Scanning paths...
     [exec] /home/senya/libphonenumber-tools/libphonenumber/javascript/../../closure-library/closure/bin/build/closurebuilder.py: 1657 sources scanned.
     [exec] /home/senya/libphonenumber-tools/libphonenumber/javascript/../../closure-library/closure/bin/build/closurebuilder.py: Building dependency tree..
     [exec] /home/senya/libphonenumber-tools/libphonenumber/javascript/../../closure-library/closure/bin/build/closurebuilder.py: Closure Compiler now natively understands and orders Closure dependencies and
     [exec] is preferred over using this script for performing JavaScript compilation.
     [exec] 
     [exec] Please migrate your codebase.
     [exec] 
     [exec] See:
     [exec] https://github.com/google/closure-compiler/wiki/Managing-Dependencies
     [exec] 
     [exec] /home/senya/libphonenumber-tools/libphonenumber/javascript/../../closure-library/closure/bin/build/closurebuilder.py: Compiling with the following command: java -client -jar /home/senya/libphonenumber-tools/libphonenumber/javascript/../../closure-compiler/bazel-bin/compiler_unshaded_deploy.jar --flagfile /tmp/tmp706rne
     [exec] java.lang.NullPointerException: No warning class for name: strictMissingRequire
     [exec]     at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:985)
     [exec]     at com.google.javascript.jscomp.DiagnosticGroups.setWarningLevel(DiagnosticGroups.java:737)
     [exec]     at com.google.javascript.jscomp.AbstractCommandLineRunner.setWarningGuardOptions(AbstractCommandLineRunner.java:328)
     [exec]     at com.google.javascript.jscomp.AbstractCommandLineRunner.setRunOptions(AbstractCommandLineRunner.java:343)
     [exec]     at com.google.javascript.jscomp.AbstractCommandLineRunner.doRun(AbstractCommandLineRunner.java:1145)
     [exec]     at com.google.javascript.jscomp.AbstractCommandLineRunner.run(AbstractCommandLineRunner.java:532)
     [exec]     at com.google.javascript.jscomp.CommandLineRunner.main(CommandLineRunner.java:2223)
     [exec] Traceback (most recent call last):
     [exec]   File "/home/senya/libphonenumber-tools/libphonenumber/javascript/../../closure-library/closure/bin/build/closurebuilder.py", line 295, in <module>
     [exec]     main()
     [exec]   File "/home/senya/libphonenumber-tools/libphonenumber/javascript/../../closure-library/closure/bin/build/closurebuilder.py", line 284, in main
     [exec]     compiler_flags=options.compiler_flags)
     [exec]   File "/home/senya/libphonenumber-tools/closure-library/closure/bin/build/jscompiler.py", line 159, in Compile
     [exec]     raise JsCompilerError('JavaScript compilation failed.')
     [exec] jscompiler.JsCompilerError: JavaScript compilation failed.

BUILD FAILED
/home/senya/libphonenumber-tools/libphonenumber/javascript/build.xml:99: The following error occurred while executing this line:
/home/senya/libphonenumber-tools/libphonenumber/javascript/build.xml:23: exec returned: 1

Total time: 2 seconds
```

It looks like the `strictMissingRequire` option is not supported by the compiler anymore but `missingRequire` is. I found at least this issue as an evidence that it was supposed to be deleted: https://github.com/google/closure-compiler/issues/1915

So I changed that to just `missingRequire`.

Also I had to add some missing requires for `goog.proto2.Descriptor` to make it compile.