### PR TITLE
116xxx German Short Number valid vs. assigned

### DIFF
--- a/resources/ShortNumberMetadata.xml
+++ b/resources/ShortNumberMetadata.xml
@@ -3403,13 +3403,7 @@
         <nationalNumberPattern>
           11(?:
             [025]|
-            6(?:
-              00[06]|
-              1(?:
-                1[167]|
-                23
-              )
-            )
+            6\d{3}
           )
         </nationalNumberPattern>
       </shortCode>


### PR DESCRIPTION
The current Meta Data for German short numbers starting with 116 are not covering any valid number as defined in the [official 116xxx ruling](https://www.bundesnetzagentur.de/SharedDocs/Downloads/DE/Sachgebiete/Telekommunikation/Unternehmen_Institutionen/Nummerierung/Rufnummern/116xyz/StrukturAusgestNrBereich_Id11155pdf.pdf?__blob=publicationFile&v=4) - it is limiting the filter to the [currently assigned numbers](https://www.bundesnetzagentur.de/DE/Sachgebiete/Telekommunikation/Unternehmen_Institutionen/Nummerierung/Rufnummern/116xyz/116xyzZugeteilteRufnumernTabelle.html?nn=326742). While this quality might be better, than just the valid numbers the corresponding methods with the term "valid" is than stricter than the "valid" check for other number groups, where you only verify that the number is defined inside the number plan but might not be assigned yet.