### PR TITLE
fix for Belarus after 2012 MNP (Mobile Number Portability) rule imple…

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -5117,15 +5117,11 @@
         <exampleNumber>294911911</exampleNumber>
         <nationalNumberPattern>
           (?:
-            2(?:
-              5[5-79]|
-              9[1-9]
-            )|
-            (?:
+            2[59]|
               33|
               44
-            )\d
-          )\d{6}
+            )
+          )\d{7}
         </nationalNumberPattern>
       </mobile>
       <!-- Putting Interactive Polling Service (free) here too. -->


### PR DESCRIPTION
*   Country: Belarus
*   Example number(s) and/or range(s):  375253854136
*   Number type ("fixed-line", "mobile", "short code", etc.): mobile
*   For short codes, cost and dialing restrictions: 
*   Where or whom did you get the number(s) from: life:) mobile operator 
*   Authoritative evidence (e.g. national numbering plan, operator announcement): https://www.telecompaper.com/news/life-belarus-runs-mobile-number-portability-promotion--1080101 the event happened 9 years ago.
*   Link from demo (http://libphonenumber.appspot.com) showing error: http://libphonenumber.appspot.com/phonenumberparser?number=375253854136