### PR TITLE
Improve multithread perf of PhoneNumberUtil.isValidNumber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,67 @@
+# File created using '.gitignore Generator' for Visual Studio Code: https://bit.ly/vscode-gig
+
+# Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode,macos,maven
+# Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode,macos,maven
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Maven ###
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,macos,maven
+
+# Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
+.idea

--- a/README.md
+++ b/README.md
@@ -284,4 +284,4 @@ cd java/libphonenumber
 mvn deploy
 ```
 
-> Note: considerate to update the version at the pom.xml before deploy lib
+> Note: consider updating the version at the pom.xml before deploying lib

--- a/README.md
+++ b/README.md
@@ -249,3 +249,39 @@ Alternatives to our own versions:
     https://github.com/seegno/google-libphonenumber - a browserify-compatible
     wrapper around the original unmodified library installable via npm, which
     packs the Google Closure library, about 420 KB in size.
+
+
+# Deploy
+
+## Configure maven settings
+
+At your `~/.m2/settings.xml` file add:
+
+```xml
+<settings>
+    <profiles>
+        <profile>
+            <id>myMavenRepo</id>
+            <activation>
+                <property>
+                    <name>!doNotUseMyMavenRepo</name>
+                </property>
+            </activation>
+            <properties>
+                <myMavenRepo.read.url>PASTE_READ_URL</myMavenRepo.read.url>
+                <myMavenRepo.write.url>PASTE_WRITE_URL</myMavenRepo.write.url>
+            </properties>
+        </profile>
+    </profiles>
+</settings>
+
+```
+
+## Run deploy
+
+```bash
+cd java/libphonenumber
+mvn deploy
+```
+
+> Note: considerate to update the version at the pom.xml before deploy lib

--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -3,15 +3,20 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>libphonenumber</artifactId>
-  <version>8.12.25-SNAPSHOT</version>
+  <version>8.12.25-4p</version>
   <packaging>jar</packaging>
   <url>https://github.com/google/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.12.25-SNAPSHOT</version>
+    <version>8.12.25</version>
   </parent>
+
+  <properties>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
+  </properties>
 
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -88,7 +93,48 @@
           </signature>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>default-deploy</id>
+            <phase>none</phase>
+            <goals>
+              <goal>deploy</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-deploy</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>deploy</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
+
+  <distributionManagement>
+    <repository>
+      <id>myMavenRepo.write</id>
+      <url>${myMavenRepo.write.url}</url>
+    </repository>
+    <snapshotRepository>
+      <id>myMavenRepo.write</id>
+      <url>${myMavenRepo.write.url}</url>
+    </snapshotRepository>
+  </distributionManagement>
 
 </project>

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/internal/RegexCache.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/internal/RegexCache.java
@@ -26,13 +26,18 @@ import java.util.regex.Pattern;
  * @author Shaopeng Jia
  */
 public class RegexCache {
-  private LRUCache<String, Pattern> cache;
+  private ThreadLocal<LRUCache<String, Pattern>> cache;
 
-  public RegexCache(int size) {
-    cache = new LRUCache<String, Pattern>(size);
+  public RegexCache(final int size) {
+    cache = new ThreadLocal<LRUCache<String, Pattern>>() {
+      @Override protected LRUCache<String, Pattern> initialValue() {
+          return new LRUCache<String, Pattern>(size);
+      }
+    };
   }
 
   public Pattern getPatternForRegex(String regex) {
+    LRUCache<String, Pattern> cache = this.cache.get();
     Pattern pattern = cache.get(regex);
     if (pattern == null) {
       pattern = Pattern.compile(regex);
@@ -43,6 +48,7 @@ public class RegexCache {
 
   // @VisibleForTesting
   boolean containsRegex(String regex) {
+    LRUCache<String, Pattern> cache = this.cache.get();
     return cache.containsKey(regex);
   }
 
@@ -63,15 +69,15 @@ public class RegexCache {
       };
     }
 
-    public synchronized V get(K key) {
+    public V get(K key) {
       return map.get(key);
     }
 
-    public synchronized void put(K key, V value) {
+    public void put(K key, V value) {
       map.put(key, value);
     }
 
-    public synchronized boolean containsKey(K key) {
+    public boolean containsKey(K key) {
       return map.containsKey(key);
     }
   }


### PR DESCRIPTION
The synchronized access in `LRUCache` is a major performance bottleneck when using libphonenumber in multithreaded environments (in my case, I'm using this lib from Apache Spark).

A synthetic test that performs 10M phone number validations on 16 cores takes 30 seconds to complete. The proposed change uses a ThreadLocal cache to avoid synchronization, which reduces the runtime of the test to just 7.8 seconds (~x3.8 improvement).

I also prototyped an alternative solution that used a ReadWriteLock, but the perf improvement wasn't so good.