### PR TITLE
Always use preferred intl prefix if present

### DIFF
--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -1384,13 +1384,18 @@ void PhoneNumberUtil::FormatOutOfCountryCallingNumber(
   const string& international_prefix =
       metadata_calling_from->international_prefix();
 
-  // For regions that have multiple international prefixes, the international
-  // format of the number is returned, unless there is a preferred international
-  // prefix.
-  const string international_prefix_for_formatting(
-      reg_exps_->single_international_prefix_->FullMatch(international_prefix)
-      ? international_prefix
-      : metadata_calling_from->preferred_international_prefix());
+  // In general, if there is a preferred international prefix, use that.
+  // Otherwise, for regions that have multiple international prefixes, the
+  // international format of the number is returned since we would not know
+  // which one to use.
+  std::string international_prefix_for_formatting;
+  if (metadata_calling_from->has_preferred_international_prefix()) {
+    international_prefix_for_formatting =
+        metadata_calling_from->preferred_international_prefix();
+  } else if (reg_exps_->single_international_prefix_->FullMatch(
+                 international_prefix)) {
+    international_prefix_for_formatting = international_prefix;
+  }
 
   string region_code;
   GetRegionCodeForCountryCode(country_code, &region_code);

--- a/cpp/test/phonenumbers/phonenumberutil_test.cc
+++ b/cpp/test/phonenumbers/phonenumberutil_test.cc
@@ -845,6 +845,12 @@ TEST_F(PhoneNumberUtilTest, FormatOutOfCountryWithPreferredIntlPrefix) {
   phone_util_.FormatOutOfCountryCallingNumber(test_number, RegionCode::AU(),
                                               &formatted_number);
   EXPECT_EQ("0011 39 02 3661 8300", formatted_number);
+  
+  // Testing preferred international prefixes with ~ are supported (designates
+  // waiting).
+  phone_util_.FormatOutOfCountryCallingNumber(test_number, RegionCode::UZ(),
+                                              &formatted_number);
+  EXPECT_EQ("8~10 39 02 3661 8300", formatted_number);
 }
 
 TEST_F(PhoneNumberUtilTest, FormatOutOfCountryKeepingAlphaChars) {

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -1576,14 +1576,15 @@ public class PhoneNumberUtil {
     PhoneMetadata metadataForRegionCallingFrom = getMetadataForRegion(regionCallingFrom);
     String internationalPrefix = metadataForRegionCallingFrom.getInternationalPrefix();
 
-    // For regions that have multiple international prefixes, the international format of the
-    // number is returned, unless there is a preferred international prefix.
+    // In general, if there is a preferred international prefix, use that. Otherwise, for regions
+    // that have multiple international prefixes, the international format of the number is
+    // returned since we would not know which one to use.
     String internationalPrefixForFormatting = "";
-    if (SINGLE_INTERNATIONAL_PREFIX.matcher(internationalPrefix).matches()) {
-      internationalPrefixForFormatting = internationalPrefix;
-    } else if (metadataForRegionCallingFrom.hasPreferredInternationalPrefix()) {
+    if (metadataForRegionCallingFrom.hasPreferredInternationalPrefix()) {
       internationalPrefixForFormatting =
           metadataForRegionCallingFrom.getPreferredInternationalPrefix();
+    } else if (SINGLE_INTERNATIONAL_PREFIX.matcher(internationalPrefix).matches()) {
+      internationalPrefixForFormatting = internationalPrefix;
     }
 
     String regionCode = getRegionCodeForCountryCode(countryCallingCode);

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
@@ -653,6 +653,10 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
     // are accepted as possible international prefixes in our test metadta.)
     assertEquals("0011 39 02 3661 8300",
                  phoneUtil.formatOutOfCountryCallingNumber(IT_NUMBER, RegionCode.AU));
+
+    // Testing preferred international prefixes with ~ are supported (designates waiting).
+    assertEquals("8~10 39 02 3661 8300",
+                 phoneUtil.formatOutOfCountryCallingNumber(IT_NUMBER, RegionCode.UZ));
   }
 
   public void testFormatOutOfCountryKeepingAlphaChars() {

--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -2144,13 +2144,13 @@ i18n.phonenumbers.PhoneNumberUtil.prototype.formatOutOfCountryCallingNumber =
   // prefix.
   /** @type {string} */
   var internationalPrefixForFormatting = '';
-  if (i18n.phonenumbers.PhoneNumberUtil.matchesEntirely(
-      i18n.phonenumbers.PhoneNumberUtil.SINGLE_INTERNATIONAL_PREFIX_,
-      internationalPrefix)) {
-    internationalPrefixForFormatting = internationalPrefix;
-  } else if (metadataForRegionCallingFrom.hasPreferredInternationalPrefix()) {
+  if (metadataForRegionCallingFrom.hasPreferredInternationalPrefix()) {
     internationalPrefixForFormatting =
         metadataForRegionCallingFrom.getPreferredInternationalPrefixOrDefault();
+  }  else if (i18n.phonenumbers.PhoneNumberUtil.matchesEntirely(
+      i18n.phonenumbers.PhoneNumberUtil.SINGLE_INTERNATIONAL_PREFIX_,
+      internationalPrefix)) {
+      internationalPrefixForFormatting = internationalPrefix;
   }
 
   /** @type {string} */

--- a/javascript/i18n/phonenumbers/phonenumberutil_test.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil_test.js
@@ -901,6 +901,12 @@ function testFormatOutOfCountryWithPreferredIntlPrefix() {
   assertEquals(
       '0011 39 02 3661 8300',
       phoneUtil.formatOutOfCountryCallingNumber(IT_NUMBER, RegionCode.AU));
+      
+  // Testing preferred international prefixes with ~ are supported (designates
+  // waiting).
+  assertEquals(
+      '8~10 39 02 3661 8300',
+      phoneUtil.formatOutOfCountryCallingNumber(IT_NUMBER, RegionCode.UZ))
 }
 
 function testFormatOutOfCountryKeepingAlphaChars() {

--- a/pending_code_changes.txt
+++ b/pending_code_changes.txt
@@ -1,2 +1,2 @@
 Code changes:
- - Always use preferred intl prefix if present, not just for numbers with a non-unique IDD. This means we will output "8~10" as the prefix if calling formatOutOfCountryCallingNumber instead of "810" for some regions that have this tilde in their prefix [designates that the user should wait before continuing to dial].
+ - Changes formatOutOfCountryCallingNumber to always use preferred intl prefix if present, not just for numbers with a non-unique IDD. This means we will output "8~10" as the prefix if calling formatOutOfCountryCallingNumber instead of "810" for some regions that have this tilde in their prefix [designates that the user should wait before continuing to dial].

--- a/pending_code_changes.txt
+++ b/pending_code_changes.txt
@@ -1,1 +1,2 @@
-
+Code changes:
+ - Always use preferred intl prefix if present, not just for numbers with a non-unique IDD. This means we will output "8~10" as the prefix if calling formatOutOfCountryCallingNumber instead of "810" for some regions that have this tilde in their prefix [designates that the user should wait before continuing to dial].

--- a/resources/phonemetadata.proto
+++ b/resources/phonemetadata.proto
@@ -181,8 +181,10 @@ message PhoneMetadata {
   // matching the international prefixes will be stored in this field.
   optional string international_prefix = 11;
 
-  // If more than one international prefix is present, a preferred prefix can
-  // be specified here for out-of-country formatting purposes. If this field is
+  // If the international prefix that we want to use when formatting the number
+  // for out-of-country dialling contains non-digit symbols, or there is more
+  // than one international prefix is present, a preferred prefix can be
+  // specified here for out-of-country formatting purposes. If this field is
   // not present, and multiple international prefixes are present, then "+"
   // will be used instead.
   optional string preferred_international_prefix = 17;

--- a/tools/java/common/test/com/google/i18n/phonenumbers/BuildMetadataFromXmlTest.java
+++ b/tools/java/common/test/com/google/i18n/phonenumbers/BuildMetadataFromXmlTest.java
@@ -113,7 +113,7 @@ public class BuildMetadataFromXmlTest extends TestCase {
       throws ParserConfigurationException, SAXException, IOException {
     String xmlInput = "<territory"
         + "  countryCode='33' leadingDigits='2' internationalPrefix='00'"
-        + "  preferredInternationalPrefix='0011' nationalPrefixForParsing='0'"
+        + "  preferredInternationalPrefix='00~11' nationalPrefixForParsing='0'"
         + "  nationalPrefixTransformRule='9$1'"  // nationalPrefix manually injected.
         + "  preferredExtnPrefix=' x' mainCountryForCode='true'"
         + "  leadingZeroPossible='true' mobileNumberPortableRegion='true'>"
@@ -124,7 +124,7 @@ public class BuildMetadataFromXmlTest extends TestCase {
     assertEquals(33, phoneMetadata.getCountryCode());
     assertEquals("2", phoneMetadata.getLeadingDigits());
     assertEquals("00", phoneMetadata.getInternationalPrefix());
-    assertEquals("0011", phoneMetadata.getPreferredInternationalPrefix());
+    assertEquals("00~11", phoneMetadata.getPreferredInternationalPrefix());
     assertEquals("0", phoneMetadata.getNationalPrefixForParsing());
     assertEquals("9$1", phoneMetadata.getNationalPrefixTransformRule());
     assertEquals("0", phoneMetadata.getNationalPrefix());


### PR DESCRIPTION
After this change, the API always use preferred intl prefix if present, not just for numbers with a non-unique IDD. This means we will output "8~10" as the prefix if calling `formatOutOfCountryCallingNumber` instead of "810" for some regions that have this tilde in their prefix [designates that the user should wait before continuing to dial].

P.S: If `formatOutOfCountryCallingNumber()` API has returned format with wrong international exit code for region calling from, [please report the issue](https://github.com/google/libphonenumber/blob/master/CONTRIBUTING.md#filing-a-metadata-issue) as it has to be corrected in metadata.
