### PR TITLE
Fix AYTF to not format when input numbers are lost in the result.

### DIFF
--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -993,10 +993,13 @@ bool PhoneNumberUtil::IsFormatEligibleForAsYouTypeFormatter(
   // the format element under numberFormat contains groups of the dollar sign
   // followed by a single digit, separated by valid phone number punctuation.
   // This prevents invalid punctuation (such as the star sign in Israeli star
-  // numbers) getting into the output of the AYTF.
+  // numbers) getting into the output of the AYTF. We require that the first
+  // group is present in the output pattern to ensure no data is lost while
+  // formatting; when we format as you type, this should always be the case.
   const RegExp& eligible_format_pattern = reg_exps_->regexp_cache_->GetRegExp(
-      StrCat("[", kValidPunctuation, "]*", "(\\$\\d", "[",
-             kValidPunctuation, "]*)+"));
+      StrCat("[", kValidPunctuation, "]*", "\\$1",
+             "[", kValidPunctuation, "]*", "(\\$\\d",
+             "[", kValidPunctuation, "]*)*"));
   return eligible_format_pattern.FullMatch(format);
 }
 

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java
@@ -70,10 +70,12 @@ public class AsYouTypeFormatter {
   // used by the AYTF. It is eligible when the format element under numberFormat contains groups of
   // the dollar sign followed by a single digit, separated by valid phone number punctuation. This
   // prevents invalid punctuation (such as the star sign in Israeli star numbers) getting into the
-  // output of the AYTF.
+  // output of the AYTF. We require that the first group is present in the output pattern to ensure
+  // no data is lost while formatting; when we format as you type, this should always be the case.
   private static final Pattern ELIGIBLE_FORMAT_PATTERN =
       Pattern.compile("[" + PhoneNumberUtil.VALID_PUNCTUATION + "]*"
-          + "(\\$\\d" + "[" + PhoneNumberUtil.VALID_PUNCTUATION + "]*)+");
+          + "\\$1" + "[" + PhoneNumberUtil.VALID_PUNCTUATION + "]*(\\$\\d"
+          + "[" + PhoneNumberUtil.VALID_PUNCTUATION + "]*)*");
   // A set of characters that, if found in a national prefix formatting rules, are an indicator to
   // us that we should separate the national prefix from the number when formatting.
   private static final Pattern NATIONAL_PREFIX_SEPARATORS_PATTERN = Pattern.compile("[- ]");

--- a/javascript/i18n/phonenumbers/asyoutypeformatter.js
+++ b/javascript/i18n/phonenumbers/asyoutypeformatter.js
@@ -212,14 +212,17 @@ i18n.phonenumbers.AsYouTypeFormatter.EMPTY_METADATA_
  * under numberFormat contains groups of the dollar sign followed by a single
  * digit, separated by valid phone number punctuation. This prevents invalid
  * punctuation (such as the star sign in Israeli star numbers) getting into the
- * output of the AYTF.
+ * output of the AYTF. We require that the first group is present in the output
+ * pattern to ensure no data is lost while formatting; when we format as you
+ * type, this should always be the case.
  * @const
  * @type {RegExp}
  * @private
  */
 i18n.phonenumbers.AsYouTypeFormatter.ELIGIBLE_FORMAT_PATTERN_ = new RegExp(
-    '^[' + i18n.phonenumbers.PhoneNumberUtil.VALID_PUNCTUATION + ']*' +
-    '(\\$\\d[' + i18n.phonenumbers.PhoneNumberUtil.VALID_PUNCTUATION + ']*)+$');
+    '^[' + i18n.phonenumbers.PhoneNumberUtil.VALID_PUNCTUATION + ']*' + '\\$1'
+    + '[' + i18n.phonenumbers.PhoneNumberUtil.VALID_PUNCTUATION + ']*(\\$\\d'
+    + '[' + i18n.phonenumbers.PhoneNumberUtil.VALID_PUNCTUATION + ']*)*$');
 
 
 /**


### PR DESCRIPTION
Earlier, AYTF is adding additional CC when returning unformatted result - for cases where the input digits are dropped for formatting.
Eg: MX case: "+5213314010666" => "+52 +5213314010666".

Why the input digits are dropped:
- In MX, the mobile token (1) is no more used, so when it is present in input, the formatted result should not contain it. However when AYTF, we should not be removing the input digits on the fly.
More details in cl/373115460 and b/183053929