### PR TITLE
Romanian mobile phone number regular expression

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -24503,7 +24503,7 @@
         <possibleLengths national="9"/>
         <exampleNumber>712034567</exampleNumber>
         <nationalNumberPattern>
-          7[01]20\d{5}|
+          7[01]2[0-9]\d{5}|
           7(?:
             0[013-9]|
             1[01]|


### PR DESCRIPTION
*   Country: Romania
*   Example number(s) and/or range(s): 712270040
*   Number type ("fixed-line", "mobile", "short code", etc.): mobile
*   Where or whom did you get the number(s) from: from client registration
*   Authoritative evidence (e.g. national numbering plan, operator announcement): https://www.ancom.ro/resurse-de-numerotatie_218 (https://www.ancom.ro/uploads/forms_files/anexa_Lurn_Orange_41573208639.pdf)
*   Link from demo (http://libphonenumber.appspot.com) showing error: https://libphonenumber.appspot.com/phonenumberparser?number=712270040&country=RO

There are a several new mobile phone numbers in Romania which are not match for the current regular expression. For example: 7122XXXXX