### PR TITLE
Unit test fix, that missed testing as part of commit #5c309c5

### DIFF
--- a/javascript/i18n/phonenumbers/phonenumberutil_test.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil_test.js
@@ -455,8 +455,7 @@ function testGetSupportedRegions() {
 
 function testGetSupportedGlobalNetworkCallingCodes() {
   assertTrue(phoneUtil.getSupportedGlobalNetworkCallingCodes().length > 0);
-  assertFalse(phoneUtil.getSupportedGlobalNetworkCallingCodes().includes(
-      RegionCode.US));
+  assertFalse(phoneUtil.getSupportedGlobalNetworkCallingCodes().includes(1));
   assertTrue(phoneUtil.getSupportedGlobalNetworkCallingCodes().includes(800));
   phoneUtil.getSupportedGlobalNetworkCallingCodes().forEach(function(
       countryCallingCode) {


### PR DESCRIPTION
```goog.array.contains(arr, obj)```, is generous to take any object type, while ES5 ```<array_type>.includes()``` is not.
https://google.github.io/closure-library/api/goog.array.html This must have been cought as part of change PR #2627; but I missed testing it. Found during the metadata release test.