### PR TITLE
Add support of 24385 for Orange D. R. Congo

### DIFF
--- a/resources/carrier/en/243.txt
+++ b/resources/carrier/en/243.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 24380|Orange
+24385|Orange
 24381|Vodacom
 24382|Vodacom
 24383|Vodacom


### PR DESCRIPTION
Orange D. R. Congo is supporting 24385 numbers which the library was not supporting. 
Phone numbers like **+2438500112233** are valid D. R. Congo phone numbers