### PR TITLE
Replace direct output to stderr with logging

### DIFF
--- a/cpp/src/phonenumbers/utf/unicodetext.cc
+++ b/cpp/src/phonenumbers/utf/unicodetext.cc
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <cstdio>
 
+#include "phonenumbers/default_logger.h"
 #include "phonenumbers/utf/unicodetext.h"
 #include "phonenumbers/utf/stringpiece.h"
 #include "phonenumbers/utf/utf.h"
@@ -231,7 +232,7 @@ UnicodeText& UnicodeText::Copy(const UnicodeText& src) {
 UnicodeText& UnicodeText::CopyUTF8(const char* buffer, int byte_length) {
   repr_.Copy(buffer, byte_length);
   if (!UniLib:: IsInterchangeValid(buffer, byte_length)) {
-    fprintf(stderr, "UTF-8 buffer is not interchange-valid.\n");
+    LOG(WARNING) << "UTF-8 buffer is not interchange-valid.";
     repr_.size_ = ConvertToInterchangeValid(repr_.data_, byte_length);
   }
   return *this;
@@ -250,7 +251,7 @@ UnicodeText& UnicodeText::TakeOwnershipOfUTF8(char* buffer,
                                               int byte_capacity) {
   repr_.TakeOwnershipOf(buffer, byte_length, byte_capacity);
   if (!UniLib:: IsInterchangeValid(buffer, byte_length)) {
-    fprintf(stderr, "UTF-8 buffer is not interchange-valid.\n");
+    LOG(WARNING) << "UTF-8 buffer is not interchange-valid.";
     repr_.size_ = ConvertToInterchangeValid(repr_.data_, byte_length);
   }
   return *this;
@@ -269,7 +270,7 @@ UnicodeText& UnicodeText::PointToUTF8(const char* buffer, int byte_length) {
   if (UniLib:: IsInterchangeValid(buffer, byte_length)) {
     repr_.PointTo(buffer, byte_length);
   } else {
-    fprintf(stderr, "UTF-8 buffer is not interchange-valid.");
+    LOG(WARNING) << "UTF-8 buffer is not interchange-valid.";
     repr_.Copy(buffer, byte_length);
     repr_.size_ = ConvertToInterchangeValid(repr_.data_, byte_length);
   }


### PR DESCRIPTION
There a few places where messages are written direct to `stderr` instead of using the logging mechanism. Our application uses structured logging on `stderr`, in the form of a stream of newline-separated JSON, and the insertion of non-JSON text breaks the validity of the stream.

This PR sends the messages through `libphonenumber`'s log mechanism instead. It breaks the code structure slightly because the code now uses the logger inside the `utf` module. However, there isn't any circularity because the logger doesn't use the `utf` code.

See [Issue 206677455](https://issuetracker.google.com/issues/206677455) for additional discussion and background.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/libphonenumber/2697)
<!-- Reviewable:end -->
