### PR TITLE
Update UK area codes

### DIFF
--- a/resources/geocoding/en/44.txt
+++ b/resources/geocoding/en/44.txt
@@ -760,7 +760,7 @@
 44239|Portsmouth
 44241|Coventry
 44247|Coventry
-44281|Northern Ireland
+4428|Northern Ireland
 442820|Ballycastle
 442821|Martinstown
 442825|Ballymena
@@ -780,6 +780,7 @@
 442868|Kesh
 442870|Coleraine
 442871|Londonderry
+442872|Londonderry
 442877|Limavady
 442879|Magherafelt
 442880|Carrickmore

--- a/resources/geocoding/en/44.txt
+++ b/resources/geocoding/en/44.txt
@@ -17,12 +17,7 @@
 # with multiple corrections and fixes applied (see previous commits).
 
 44113|Leeds
-441140|Sheffield
-441141|Sheffield
-441142|Sheffield
-441143|Sheffield
-441144|Sheffield
-441145|Sheffield
+44114|Sheffield
 44115|Nottingham
 44116|Leicester
 44117|Bristol

--- a/resources/geocoding/en/44.txt
+++ b/resources/geocoding/en/44.txt
@@ -293,12 +293,6 @@
 441477|Holmes Chapel
 441478|Isle of Skye - Portree
 441479|Grantown-on-Spey
-44147981|Aviemore
-44147982|Nethy Bridge
-44147983|Boat of Garten
-44147984|Carrbridge
-44147985|Dulnain Bridge
-44147986|Cairngorm
 441480|Huntingdon
 441481|Guernsey
 441482|Kingston-upon-Hull

--- a/resources/geocoding/en/44.txt
+++ b/resources/geocoding/en/44.txt
@@ -396,7 +396,9 @@
 441592|Kirkcaldy
 441593|Lybster
 441594|Lydney
-441595|Lerwick, Foula & Fair Isle
+441595|Lerwick
+44159575|Foula
+44159576|Fair Isle
 441597|Llandrindod Wells
 441598|Lynton
 441599|Kyle

--- a/resources/geocoding/en/44.txt
+++ b/resources/geocoding/en/44.txt
@@ -30,15 +30,7 @@
 441207|Consett
 441208|Bodmin
 441209|Redruth
-441210|Birmingham
-441211|Birmingham
-441212|Birmingham
-441213|Birmingham
-441214|Birmingham
-441215|Birmingham
-441216|Birmingham
-441217|Birmingham
-4412180|Birmingham
+44121|Birmingham
 441223|Cambridge
 441224|Aberdeen
 441225|Bath


### PR DESCRIPTION
Some minor updates to bring geocoding more into line with [OFCOM's published data](https://www.ofcom.org.uk/__data/assets/pdf_file/0013/102613/national-numbering-plan.pdf). Alas, they appear to not publish this in machine-readable form any more.