### PR TITLE
fix build error with clang and gcc "

### DIFF
--- a/cpp/src/phonenumbers/stringutil.cc
+++ b/cpp/src/phonenumbers/stringutil.cc
@@ -88,7 +88,7 @@ bool HasSuffixString(const string& s, const string& suffix) {
 
 template <typename T>
 void GenericAtoi(const string& s, T* out) {
-  absl::SimpleAtoi(s, out);
+  (void)absl::SimpleAtoi(s, out);
 }
 
 void safe_strto32(const string& s, int32 *n) {

--- a/cpp/src/phonenumbers/stringutil.cc
+++ b/cpp/src/phonenumbers/stringutil.cc
@@ -88,7 +88,8 @@ bool HasSuffixString(const string& s, const string& suffix) {
 
 template <typename T>
 void GenericAtoi(const string& s, T* out) {
-  (void)absl::SimpleAtoi(s, out);
+  if (!absl::SimpleAtoi(s, out))
+    *out = 0;
 }
 
 void safe_strto32(const string& s, int32 *n) {


### PR DESCRIPTION
This very minor, trivial and risk free commit fix

introduced in 8.12.45 with #2734

 error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]"

Without this fix, I cannot build using clang++13

@penmetsaa @jeaiii @katbohm 