### PR TITLE
Making it clear that safe_strtou64 kind of string to int conversion apis fail when non decimal chars are present.

### DIFF
--- a/cpp/src/phonenumbers/stringutil.cc
+++ b/cpp/src/phonenumbers/stringutil.cc
@@ -88,7 +88,8 @@ bool HasSuffixString(const string& s, const string& suffix) {
 
 template <typename T>
 void GenericAtoi(const string& s, T* out) {
-  (void)absl::SimpleAtoi(s, out);
+  if (!absl::SimpleAtoi(s, out))
+    *out = 0;
 }
 
 void safe_strto32(const string& s, int32 *n) {

--- a/cpp/src/phonenumbers/stringutil.cc
+++ b/cpp/src/phonenumbers/stringutil.cc
@@ -88,8 +88,7 @@ bool HasSuffixString(const string& s, const string& suffix) {
 
 template <typename T>
 void GenericAtoi(const string& s, T* out) {
-  if (!absl::SimpleAtoi(s, out))
-    *out = 0;
+  (void)absl::SimpleAtoi(s, out);
 }
 
 void safe_strto32(const string& s, int32 *n) {

--- a/cpp/test/phonenumbers/stringutil_test.cc
+++ b/cpp/test/phonenumbers/stringutil_test.cc
@@ -135,7 +135,7 @@ TEST(StringUtilTest, safe_strtou64) {
   safe_strtou64("16", &n);
   EXPECT_EQ(16U, n);
 
-  safe_strtou64("18446744073709551615UL", &n);
+  safe_strtou64("18446744073709551615", &n);
   EXPECT_EQ(18446744073709551615ULL, n);
 }
 


### PR DESCRIPTION
Fix for UT breakage after https://github.com/google/libphonenumber/pull/2742.
```
[ RUN      ] StringUtilTest.safe_strtou64
/usr/local/google/home/penmetsaa/github_lab/libphonenumber/cpp/test/phonenumbers/stringutil_test.cc:139: Failure
Expected equality of these values:
  18446744073709551615ULL
    Which is: 18446744073709551615
  n
    Which is: 0
```
Though there is a failure in conversion, fortunately the job is done, though absl mark it as [unspecified state](https://github.com/abseil/abseil-cpp/blob/5ed77665c4d697f657fa1362b5a482450f858cdc/absl/strings/numbers.h#L63) 
Looks like just "void" is better sol in this case. More details there.