### PR TITLE
Add 976 for Nepal

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -22442,7 +22442,7 @@
         <nationalNumberPattern>
           9(?:
             6[0-3]|
-            7[245]|
+            7[2456]|
             8[0-24-68]
           )\d{7}
         </nationalNumberPattern>


### PR DESCRIPTION
`976` is a newly added number scheme for Nepal Telecom mobile phones in Nepal.

Issue Tracker: https://issuetracker.google.com/issues/229508074

### Resources:
1. [Nepal Telecom Notice (in Nepali language)](https://www.ntc.net.np/notices/l-l-cdma-lii-aa-a-gsm-4g-b), [Translated](https://www-ntc-net-np.translate.goog/notices/l-l-cdma-lii-aa-a-gsm-4g-b?_x_tr_sl=ne&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)
2. [NepaliTelecom News](https://www.nepalitelecom.com/2021/11/nta-ordered-ntc-stop-distributing-974-range-mobile-numbers.html#:~:text=NTA%20though%20has%20maintained%20that%20NTC%20could%20continue%20using%20976%20range%20numbers.)