### PR TITLE
update SE mobile pattern

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -25609,9 +25609,9 @@
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
-        <possibleLengths national="9"/>
+        <possibleLengths national="9,13"/>
         <exampleNumber>701234567</exampleNumber>
-        <nationalNumberPattern>7[02369]\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>7[012369]\d{7,11}</nationalNumberPattern>
       </mobile>
       <pager>
         <possibleLengths national="9"/>


### PR DESCRIPTION
Adding a new numbering range for Sweden according to the requirements of the Swedish numbering plan for telephony.
https://www.pts.se/contentassets/156d4de72d0e403cb5be0bcc29e0c4f3/the-swedish-numbering-plan-for-telephony-accordning-to-itu---2022-01-04.pdf