### PR TITLE
Wrong region name for `34872` prefix in geocoding data

### DIFF
--- a/resources/geocoding/en/34.txt
+++ b/resources/geocoding/en/34.txt
@@ -55,7 +55,7 @@
 34868|Murcia
 34869|Cuenca
 34871|Balearic Islands
-34872|Gerona
+34872|Girona
 34873|Lleida
 34874|Huesca
 34875|Soria
@@ -156,7 +156,7 @@
 349698|Cuenca
 349699|Cuenca
 34971|Balearic Islands
-34972|Gerona
+34972|Girona
 349730|Lleida
 349731|Lleida
 349732|Lleida


### PR DESCRIPTION
Girona is a city in the northeast region of Catalonia. There, the official language is Catalan (alongside of Spanish).

Catalonia has 4 provinces: Barcelona, Tarragona, Lleida and Girona.

All but Girona has its correct name in this file. Girona has its Spanish translation "Gerona".


**Wikipedia**
City of Girona: https://en.wikipedia.org/wiki/Girona
Province of Girona: https://en.wikipedia.org/wiki/Province_of_Girona
Provinces of Spain: https://en.wikipedia.org/wiki/Provinces_of_Spain