### PR TITLE
Use a system-installed abseil when available

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required (VERSION 3.11)
 
 # Pick the C++ standard to compile with.
 # Abseil currently supports C++11, C++14, and C++17.
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard used to compile this project")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project (libphonenumber)
@@ -203,6 +203,8 @@ add_custom_command (
 )
 
 if (${BUILD_GEOCODER} STREQUAL "ON")
+  find_package(absl)
+
   # Geocoding data cpp file generation
   set (TOOLS_DIR "${CMAKE_CURRENT_BINARY_DIR}/tools")
   add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../tools/cpp" "${TOOLS_DIR}")

--- a/tools/cpp/CMakeLists.txt
+++ b/tools/cpp/CMakeLists.txt
@@ -28,27 +28,29 @@ project (generate_geocoding_data)
 include (gtest.cmake)
 include (FetchContent)
 
-# Downloading the abseil sources.
-FetchContent_Declare(
-    abseil-cpp
-    GIT_REPOSITORY  https://github.com/abseil/abseil-cpp.git
-    GIT_TAG         origin/master
-)
+if(NOT absl_FOUND)
+  # Downloading the abseil sources.
+  FetchContent_Declare(
+      abseil-cpp
+      GIT_REPOSITORY  https://github.com/abseil/abseil-cpp.git
+      GIT_TAG         origin/master
+  )
 
-# Building the abseil binaries
-FetchContent_GetProperties(abseil-cpp)
-if (NOT abseil-cpp_POPULATED)
-    FetchContent_Populate(abseil-cpp)
-endif ()
+  # Building the abseil binaries
+  FetchContent_GetProperties(abseil-cpp)
+  if (NOT abseil-cpp_POPULATED)
+      FetchContent_Populate(abseil-cpp)
+  endif ()
 
-if (NOT abseil-cpp_POPULATED)
-   message (FATAL_ERROR "Could not build abseil-cpp binaries.")
-endif ()
+  if (NOT abseil-cpp_POPULATED)
+     message (FATAL_ERROR "Could not build abseil-cpp binaries.")
+  endif ()
 
-# Safeguarding against any potential link errors as mentioned in
-# https://github.com/abseil/abseil-cpp/issues/225
-set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
-add_subdirectory(${abseil-cpp_SOURCE_DIR} ${abseil-cpp_BINARY_DIR})
+  # Safeguarding against any potential link errors as mentioned in
+  # https://github.com/abseil/abseil-cpp/issues/225
+  set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+  add_subdirectory(${abseil-cpp_SOURCE_DIR} ${abseil-cpp_BINARY_DIR})
+endif()
 
 find_or_build_gtest ()
 set (


### PR DESCRIPTION
Currently, CMake is configured to download and build abseil from source
whenever `BUILD_GEOCODER` is set to `ON`. Let's allow users to use a
pre-existing installation of abseil by checking for one first before
attempting to download and build another one.

If CMake finds a pre-existing installation of abseil, it will use that
instead.

We need to allow the user to override `CMAKE_CXX_STANDARD` because they
may have built abseil with a newer standard than C++11. Attempting to
build libphonenumber with C++11 will fail if abseil was built with a
newer C++ standard.

Closes #2772.
