### PR TITLE
Fixating the absl-cpp version that we download and cpp readme update after #2791

### DIFF
--- a/cpp/README
+++ b/cpp/README
@@ -135,6 +135,31 @@ Requirements:
     Note: Boost Thread is the only library needed at link time.
 
 
+  - abseil-cpp
+    As this dependency package might not be very common, we are downloading,
+    building and linking this library as part of the regular build process i.e
+    part of CMake/Make instructions. If you wish to install this C++ developer
+    library at your system level and avoid building every time, you can try
+    below instruction set.
+
+    Installation:
+    - Official [installation guide](https://abseil.io/docs/cpp/tools/cmake-installs).
+      Something that we followed in Linux system.
+      $ git clone https://github.com/abseil/abseil-cpp.git --branch
+      273292d1cfc0a94a65082ee350509af1d113344d --single-branch
+      $ cd abseil-cpp
+      $ cmake . -DCMAKE_INSTALL_PREFIX="$HOME/lpn-deps" -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+      $ cmake --build . --target install
+    - When building libphonenumber library, if abseil-cpp is still getting downloaded and
+      built, use flags like ```CMAKE_PREFIX_PATH="$HOME/lpn-deps"```
+    - Notes:
+      - We are cloning only a particular version of the abseil-cpp so that we
+	are not commiting to catch up with new build requirements of that
+	library. Eg: After the above tag version C++14 is made as minimum
+	version to build abseil-cpp library.
+      - libphonenumber is presently using C++11 by default, you can always
+	change it by passing ```CMAKE_CXX_STANDARD``` flag.
+
 Building and testing the library
 --------------------------------
   $ cd libphonenumber/cpp

--- a/cpp/README
+++ b/cpp/README
@@ -145,8 +145,7 @@ Requirements:
     Installation:
     - Official [installation guide](https://abseil.io/docs/cpp/tools/cmake-installs).
       Something that we followed in Linux system.
-      $ git clone https://github.com/abseil/abseil-cpp.git --branch
-      273292d1cfc0a94a65082ee350509af1d113344d --single-branch
+      $ git clone https://github.com/abseil/abseil-cpp.git --branch 273292d --single-branch
       $ cd abseil-cpp
       $ cmake . -DCMAKE_INSTALL_PREFIX="$HOME/lpn-deps" -DCMAKE_POSITION_INDEPENDENT_CODE=ON
       $ cmake --build . --target install

--- a/tools/cpp/CMakeLists.txt
+++ b/tools/cpp/CMakeLists.txt
@@ -29,11 +29,12 @@ include (gtest.cmake)
 include (FetchContent)
 
 if(NOT absl_FOUND)
-  # Downloading the abseil sources.
+  # Downloading the abseil sources at particular version to not catch up
+  # with its new build requirements like min C++14 is mandated in that lib.
   FetchContent_Declare(
       abseil-cpp
       GIT_REPOSITORY  https://github.com/abseil/abseil-cpp.git
-      GIT_TAG         origin/master
+      GIT_TAG         273292d1cfc0a94a65082ee350509af1d113344d
   )
 
   # Building the abseil binaries

--- a/tools/cpp/CMakeLists.txt
+++ b/tools/cpp/CMakeLists.txt
@@ -34,7 +34,7 @@ if(NOT absl_FOUND)
   FetchContent_Declare(
       abseil-cpp
       GIT_REPOSITORY  https://github.com/abseil/abseil-cpp.git
-      GIT_TAG         273292d1cfc0a94a65082ee350509af1d113344d
+      GIT_TAG         273292d
   )
 
   # Building the abseil binaries


### PR DESCRIPTION
- We are cloning only a particular version of the abseil-cpp so that we
   are not commiting to catch up with new build requirements of that
   library. Eg: In recent absl-cop release C++14 is made as minimum
   version to build the library.
- **Error details in b/239501609**
- Readme update w.r.t new abseil-cpp dependency changes i.e after
   #2791