### PR TITLE
Add the new wana extension: (53899)

### DIFF
--- a/resources/geocoding/fr/212.txt
+++ b/resources/geocoding/fr/212.txt
@@ -76,6 +76,7 @@
 2125380|Rabat et alentours
 2125388|Tanger et alentours
 21253890|Fès/Maknès et alentours
+21253899|Tangier-Tetouan/Chefchaouen
 2125393|Tanger
 2125394|Asilah
 2125395|Larache


### PR DESCRIPTION
Hello team 
i would like to inform you that wana / INWI operator added a new extension ( 53899 )
I've tried to add it here.
can someone check it an tell me if that is the right way to add it 

here's the source 

https://www.itu.int/oth/T0202000090/en

https://www.itu.int/dms_pub/itu-t/oth/02/02/T02020000900022PDFE.pdf

*   Country: Morocco
*   Example number(s) and/or range(s): [0538-946062](tel:0538946062)
*   Number type ("fixed-line", "mobile", "short code", etc.): fixed-line
*   For short codes, cost and dialing restrictions:
*   Where or whom did you get the number(s) from: From a a client
*   Authoritative evidence (e.g. national numbering plan, operator announcement): 
https://www.itu.int/dms_pub/itu-t/oth/02/02/T02020000900022PDFE.pdf
*   Link from demo (http://libphonenumber.appspot.com) showing error: http://libphonenumber.appspot.com/phonenumberparser?number=0538946062&country=212
