### PR TITLE
Update the soy-compiler running phase

### DIFF
--- a/java/demo/pom.xml
+++ b/java/demo/pom.xml
@@ -140,7 +140,7 @@
             <goals>
               <goal>exec</goal>
             </goals>
-            <phase>install</phase>
+            <phase>verify</phase>
             <configuration>
               <executable>java</executable>
               <arguments>


### PR DESCRIPTION
As release plugin only runs till ```verify``` phase during ```release:prepare```,
the class files are not being part of the demo bundle.
Now this ```exec plugin (soy-compiler)``` will run at ```verify``` phase itself