### PR TITLE
Add Swift project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ maintenance processes.
 *   C#: https://github.com/twcclegg/libphonenumber-csharp
 *   Go: https://github.com/nyaruka/phonenumbers
 *   Objective-c: https://github.com/iziz/libPhoneNumber-iOS
+*   Swift: https://github.com/marmelroy/PhoneNumberKit
 *   PHP: https://github.com/giggsey/libphonenumber-for-php
 *   PostgreSQL in-database types: https://github.com/blm768/pg-libphonenumber
 *   Python: https://github.com/daviddrysdale/python-phonenumbers


### PR DESCRIPTION
Adds the Swift project [PhoneNumberKit](https://github.com/marmelroy/PhoneNumberKit) to the README for discoverability.

The motivation for this addition is that the currently linked iOS project, [libPhoneNumber-iOS](https://github.com/iziz/libPhoneNumber-iOS), is no longer maintained (last committed in 2021, last version published to cocoapods in 2019) by the author. The proposed Swift project is also based on libPhoneNumber, but is actively maintained and the author is regularly accepting pull requests.