### PR TITLE
Move find_package call for absl to global scope

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -202,8 +202,8 @@ add_custom_command (
   DEPENDS ${PROTOBUF_SOURCES}
 )
 
+find_package(absl REQUIRED)
 if (${BUILD_GEOCODER} STREQUAL "ON")
-  find_package(absl)
 
   # Geocoding data cpp file generation
   set (TOOLS_DIR "${CMAKE_CURRENT_BINARY_DIR}/tools")


### PR DESCRIPTION
absl is needed for compilation also with GEOCODER disabled.

Signed-off-by: Andreas Cord-Landwehr <cordlandwehr@kde.org>