### PR TITLE
CPP: Fix typo in arguments to add_metadata_gen_target()

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -394,7 +394,7 @@ add_metadata_gen_target (
   ${TEST_METADATA_TARGET}
   "${RESOURCES_DIR}/PhoneNumberMetadataForTesting.xml"
   "test_metadata"
-  "metadata"
+  "test_metadata"
 )
 list (APPEND TESTING_LIBRARY_SOURCES "src/phonenumbers/test_metadata.cc")
 


### PR DESCRIPTION
This commit resolves an issue with duplicate generation of metadata.h.