### PR TITLE
Switch to Mockito Core and bump up its version to be in compatible with newer Java 17+ versions.

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -237,10 +237,9 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
+      <artifactId>mockito-core</artifactId>
+      <version>2.23.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
-
 </project>


### PR DESCRIPTION
- We are getting errors like ```java.lang.NoClassDefFoundError: Could not initialize class org.mockito.internal.creation.cglib.ClassImposterizer$3``` during release steps like ```mvn clean deploy ```; Happening in ```mvn test``` as it is UT error whenever we tried mock and object.
- After checking online https://github.com/powsybl/powsybl-diagram/issues/398 and https://github.com/mockito/mockito/issues/638, it looks like we need to bump up Mockito's version inorder to be compatible with newer Java 17+ versions.
- For our build, we are using newer open JDK 17 from our last builds. I am not sure why this has not happened last time.
- As Mockito-all is deprecated and not needed, moved to Mockito core based on https://www.baeldung.com/mockito-core-vs-mockito-all
- Moved to recent (but a bit old) popular version 2.23.4