### PR TITLE
Bumpup war plugin version for demo site as the default Maven's one is not compatible with JDK17

### DIFF
--- a/java/demo/pom.xml
+++ b/java/demo/pom.xml
@@ -102,6 +102,11 @@
         <groupId>org.apache.maven.plugins</groupId>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.3.1</version>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.1.0</version>


### PR DESCRIPTION
- Got this error when ran ```mvn deploy```
```
Error injecting constructor, java.lang.ExceptionInInitializerError
  at org.apache.maven.plugin.war.WarMojo.<init>(Unknown Source)
  while locating org.apache.maven.plugin.war.WarMojo
```
- Fix is inspired from https://stackoverflow.com/questions/66920567/error-injecting-org-apache-maven-plugin-war-warmojo