### PR TITLE
build: drop c++11 support

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,8 +19,8 @@ cmake_minimum_required (VERSION 3.11)
 project (libphonenumber VERSION 8.13.0)
 
 # Pick the C++ standard to compile with.
-# Abseil currently supports C++11, C++14, and C++17.
-set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard used to compile this project")
+# Abseil currently supports C++14, and C++17.
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard used to compile this project")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
@@ -111,7 +111,7 @@ find_package(absl)
 if(NOT absl_FOUND)
   # Overide abseil install rules for subprojects
   set(ABSL_ENABLE_INSTALL ON)
-  
+
   # Downloading the abseil sources at particular version to not catch up
   # with its new build requirements like min C++14 is mandated in that lib.
   FetchContent_Declare(

--- a/tools/cpp/CMakeLists.txt
+++ b/tools/cpp/CMakeLists.txt
@@ -17,8 +17,8 @@
 cmake_minimum_required (VERSION 3.11)
 
 # Pick the C++ standard to compile with.
-# Abseil currently supports C++11, C++14, and C++17.
-set(CMAKE_CXX_STANDARD 11)
+# Abseil currently supports 4C++14, and C++17.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project (generate_geocoding_data)
@@ -56,4 +56,3 @@ if (BUILD_TESTING)
   add_executable (generate_geocoding_data_test ${TEST_SOURCES})
   target_link_libraries (generate_geocoding_data_test absl::btree ${TEST_LIBS} absl::node_hash_set)
 endif()
-


### PR DESCRIPTION
Per [the most recent Abseil release](https://github.com/abseil/abseil-cpp/releases/tag/20230125.0), c++11 support is droped.

```
  /opt/homebrew/include/absl/base/policy_checks.h:79:2: error: "C++ versions less than C++14 are not supported."
  #error "C++ versions less than C++14 are not supported."
```

relates to https://github.com/Homebrew/homebrew-core/pull/121718