### PR TITLE
Solving leaks within Windows

### DIFF
--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -888,6 +888,12 @@ PhoneNumberUtil::~PhoneNumberUtil() {
   gtl::STLDeleteContainerPairSecondPointers(
       country_calling_code_to_region_code_map_->begin(),
       country_calling_code_to_region_code_map_->end());
+
+  for (std::map<string, PhoneMetadata>::iterator it = region_to_metadata_map_->begin(); 
+      it != region_to_metadata_map_->end(); 
+      ++it) {
+    it->second.Clear();      
+  }
 }
 
 void PhoneNumberUtil::GetSupportedRegions(std::set<string>* regions)


### PR DESCRIPTION
There's a bug where the critical section used by in the win32 Singleton implementation is never deleted. This causes it to be leaked within Windows. Therefore, changing it to a different type of lock, SRWLOCK which doesn't require "init" or "deinit" and there will be nothing to leak. Also removing the double-check for (once_init_) since with the SRWLOCK, it is no longer needed.

There's also another bug within the phonenumberutil.cc file where the PhoneMetadata members are being leaked. This PR adds clean up code for that.
