### PR TITLE
Bump up the version of Staging plugin as it is failing to access java.base mudule's java.util apis

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -169,6 +169,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
+	<version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>sonatype-nexus-staging</serverId>


### PR DESCRIPTION
Looks like after the latest bumpup of java version (i.e system level JDK to JDK11- just during the build time), the modular system is not going well with  nexus-staging-maven-plugin. Hence the error:
```
ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:deploy (injected-nexus-deploy) on project libphonenumber-parent: Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:deploy failed: An API incompatibility was encountered while executing org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:deploy: java.lang.ExceptionInInitializerError: null
    [ERROR] -----------------------------------------------------
    [ERROR] realm =    extension>org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8
    [ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
    [ERROR] urls[0] = file:/usr/local/google/home/rnidhi/.m2/repository/org/sonatype/plugins/nexus-staging-maven-plugin/1.6.8/nexus-staging-maven-plugin-1.6.8.jar
   ...
    [ERROR] urls[39] = file:/usr/local/google/home/rnidhi/.m2/repository/ch/qos/logback/logback-core/1.1.2/logback-core-1.1.2.jar
    [ERROR] urls[40] = file:/usr/local/google/home/rnidhi/.m2/repository/ch/qos/logback/logback-classic/1.1.2/logback-classic-1.1.2.jar
    [ERROR] Number of foreign imports: 1
    [ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
    [ERROR]
    [ERROR] -----------------------------------------------------
    [ERROR] : Unable to make field private final java.util.Comparator java.util.TreeMap.comparator accessible: module java.base does not "opens java.util" to unnamed module @23e44287
    [ERROR] -> [Help 1]
    [ERROR]
```

Fix inspired from pages:
- https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
- https://issues.sonatype.org/browse/NEXUS-27902