### PR TITLE
Fixing JSC_JSDOC_MISSING_TYPE_WARNING; The type declaration is missing in new API extractPhoneContext_

### DIFF
--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -4386,7 +4386,7 @@ i18n.phonenumbers.PhoneNumberUtil.prototype.parseHelper_ =
 /**
  * Extracts the value of the phone-context parameter of numberToExtractFrom,
  * following the syntax defined in RFC3966.
- * @param numberToExtractFrom
+ * @param {?string} numberToExtractFrom
  * @return {string|null} the extracted string (possibly empty), or null if no
  * phone-context parameter is found.
  * @private


### PR DESCRIPTION
This change fixes err:

```
javascript/libphonenumber/i18n/phonenumbers/phonenumberutil.js:4389:10: ERROR - [JSC_JSDOC_MISSING_TYPE_WARNING] Missing type declaration.
  4389|  * @param numberToExtractFrom
```