### PR TITLE
Adding CODEOWNERS so the approvers (of PRs) were organized

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# The libphonenumber team can approve changes in all the paths in the project.
+# This is done to make maintainance easy. Eg: Release cop can also approve changes going in.
+*       @google/libphonenumber


### PR DESCRIPTION
- Even now, only the members of the team can only approve the changes, but this is made evident and in future we can make different  members/team to own a path.
- This change is inspired from recent security recommendations from Github. b/275500757
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
- Made necessary security changes, like master "is now read-only", "min 2 reviews needed before merge".. etc
https://github.com/google/libphonenumber/settings/branches