### PR TITLE
Revert "Maven update (#2998) for release 8.13.12"

### DIFF
--- a/java/carrier/pom.xml
+++ b/java/carrier/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>carrier</artifactId>
-  <version>1.197-SNAPSHOT</version>
+  <version>1.196-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/google/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.13.13-SNAPSHOT</version>
+    <version>8.13.12-SNAPSHOT</version>
   </parent>
 
   <build>
@@ -79,12 +79,12 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.13.13-SNAPSHOT</version>
+      <version>8.13.12-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>prefixmapper</artifactId>
-      <version>2.207-SNAPSHOT</version>
+      <version>2.206-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/demo/pom.xml
+++ b/java/demo/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>demo</artifactId>
-  <version>8.13.13-SNAPSHOT</version>
+  <version>8.13.12-SNAPSHOT</version>
   <packaging>war</packaging>
   <url>https://github.com/google/libphonenumber/</url>
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.13.13-SNAPSHOT</version>
+    <version>8.13.12-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -68,17 +68,17 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.13.13-SNAPSHOT</version>
+      <version>8.13.12-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>geocoder</artifactId>
-      <version>2.207-SNAPSHOT</version>
+      <version>2.206-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>carrier</artifactId>
-      <version>1.197-SNAPSHOT</version>
+      <version>1.196-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/geocoder/pom.xml
+++ b/java/geocoder/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>geocoder</artifactId>
-  <version>2.207-SNAPSHOT</version>
+  <version>2.206-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/google/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.13.13-SNAPSHOT</version>
+    <version>8.13.12-SNAPSHOT</version>
   </parent>
 
   <build>
@@ -87,12 +87,12 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.13.13-SNAPSHOT</version>
+      <version>8.13.12-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>prefixmapper</artifactId>
-      <version>2.207-SNAPSHOT</version>
+      <version>2.206-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/internal/prefixmapper/pom.xml
+++ b/java/internal/prefixmapper/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>prefixmapper</artifactId>
-  <version>2.207-SNAPSHOT</version>
+  <version>2.206-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/google/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.13.13-SNAPSHOT</version>
+    <version>8.13.12-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.13.13-SNAPSHOT</version>
+      <version>8.13.12-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>libphonenumber</artifactId>
-  <version>8.13.13-SNAPSHOT</version>
+  <version>8.13.12-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/google/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.13.13-SNAPSHOT</version>
+    <version>8.13.12-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>libphonenumber-parent</artifactId>
-  <version>8.13.13-SNAPSHOT</version>
+  <version>8.13.12-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>https://github.com/google/libphonenumber/</url>
 


### PR DESCRIPTION
This we are reverting as we are facing error "No SCM URL was provided to perform the release" ```release:perform``` and not able to proceed. None of the things working evethough tried with differenr SCM URLs - release.prop / -DconnectionURL
 

