### PR TITLE
Add Palestine edge case on country code

### DIFF
--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/CountryCodeToRegionCodeMap.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/CountryCodeToRegionCodeMap.java
@@ -887,7 +887,16 @@ public class CountryCodeToRegionCodeMap {
 
     listWithRegionCode = new ArrayList<String>(1);
     listWithRegionCode.add("IL");
+    listWithRegionCode.add("PS");
     countryCodeToRegionCodeMap.put(972, listWithRegionCode);
+
+    listWithRegionCode = new ArrayList<String>(1);
+    listWithRegionCode.add("PS");
+    countryCodeToRegionCodeMap.put(97256, listWithRegionCode);
+
+    listWithRegionCode = new ArrayList<String>(1);
+    listWithRegionCode.add("PS");
+    countryCodeToRegionCodeMap.put(97258, listWithRegionCode);
 
     listWithRegionCode = new ArrayList<String>(1);
     listWithRegionCode.add("BH");


### PR DESCRIPTION
Referencing a [wiki](https://en.wikipedia.org/wiki/Telephone_numbers_in_the_State_of_Palestine) article describing the state of country codes in palestine & israel.