### PR TITLE
Make C++ standard handling more consistent

### DIFF
--- a/tools/cpp/CMakeLists.txt
+++ b/tools/cpp/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required (VERSION 3.11)
 
 # Pick the C++ standard to compile with.
 # Abseil currently supports C++11, C++14, and C++17.
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard used to compile this project")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project (generate_geocoding_data)


### PR DESCRIPTION
In 035901b78dbe5a6fddc9e758f0069c310750db72, we updated `cpp/CMakeLists.txt` to respect the user's configuration of `CMAKE_CXX_STANDARD`.

It turns out that this is not sufficient for some build configurations, because the user's configuration is still overridden inside `tools/cpp/CMakeLists.txt`.

Let's fix that so that the handling of `CMAKE_CXX_STANDARD` is consistent throughout the project.