### PR TITLE
Update in Fixed Line Phone Numbering for Artemisa Province, Cuba

### DIFF
--- a/resources/metadata/53/ranges.csv
+++ b/resources/metadata/53/ranges.csv
@@ -11,8 +11,9 @@ Prefix ; Length ; Type       ; Tariff        ; Area Code Length ; Operator ; For
 43     ; 8      ; FIXED_LINE ; STANDARD_RATE ; 2                ;          ; "fixed_2/4-6" ; "CU"    ; "Cienfuegos Province"       ; GOVERNMENT
 45     ; 7,8    ; FIXED_LINE ; STANDARD_RATE ; 2                ;          ; "fixed_2/4-6" ; "CU"    ; "Matanzas Province"         ; GOVERNMENT
 46     ; 8      ; FIXED_LINE ; STANDARD_RATE ; 2                ;          ; "fixed_2/4-6" ; "CU"    ; "Isle of Youth"             ; GOVERNMENT
-47     ; 7,8    ; FIXED_LINE ; STANDARD_RATE ; 2                ;          ; "fixed_2/4-6" ; "CU"    ; "Mayabeque and Artemisa"    ; GOVERNMENT
+47     ; 7,8    ; FIXED_LINE ; STANDARD_RATE ; 2                ;          ; "fixed_2/4-6" ; "CU"    ; "Mayabeque"                 ; GOVERNMENT
 48     ; 6-8    ; FIXED_LINE ; STANDARD_RATE ; 2                ;          ; "fixed_2/4-6" ; "CU"    ; "Pinar del Río Province"    ; GOVERNMENT
+49     ; 6-8    ; FIXED_LINE ; STANDARD_RATE ; 2                ;          ; "fixed_2/4-6" ; "CU"    ; "Artemisa"                  ; GOVERNMENT
 5      ; 8      ; MOBILE     ; STANDARD_RATE ;                  ; "etecsa" ; "mobile_1/7"  ; "CU"    ;                             ; GOVERNMENT
 7      ; 7,8    ; FIXED_LINE ; STANDARD_RATE ; 1                ;          ; "fixed_1/6-7" ; "CU"    ; "Havana City"               ; GOVERNMENT
 800    ; 10     ; FIXED_LINE ; TOLL_FREE     ;                  ;          ; "fixed_3/7"   ; "CU"    ;                             ; GOVERNMENT


### PR DESCRIPTION
# Summary

Effective from June 24, 2023, the fixed line phone numbering for Artemisa province in Cuba has been changed. The first two digits (47 and 48) have been replaced by 49 for all fixed line phone numbers in the province. 

# Details

1. The prefix for Artemisa, Alquízar, Güira de Melena, Guanajay, Mariel, Caimito, Bauta, and San Antonio de los Baños has been updated from 47 to 49. 

Example: 

Previous number: 4736 XXXX

Current number: 4936 XXXX

2. The prefix for Candelaria, San Cristóbal, and Bahía Honda has been updated from 48 to 49. 

Example: 

Previous number: 4859 XXXX

Current number: 4959 XXXX

# Note
This change was only applicable to fixed line phone numbers. The mobile phone numbers and Alternative Fixed Telephony (TFA) numbers remained unchanged. 

This PR reflects these changes in the official documentation and data. For more information, please refer to the official announcement [here](https://www.etecsa.cu/es/promocion/nuevonumero-Artemisa).