### PR TITLE
Fix compatibility with RE2 2023-07-01.

### DIFF
--- a/cpp/src/phonenumbers/regexp_adapter_re2.cc
+++ b/cpp/src/phonenumbers/regexp_adapter_re2.cc
@@ -39,7 +39,7 @@ class RE2RegExpInput : public RegExpInput {
         utf8_input_(string_) {}
 
   virtual string ToString() const {
-    return utf8_input_.ToString();
+    return string_;
   }
 
   StringPiece* Data() {


### PR DESCRIPTION
First discovered in https://github.com/microsoft/vcpkg/pull/32595 , Google RE2 no longer provides their own custom StringPiece type, and instead use abseil::string_view (which may end up being std::string_view).

https://github.com/google/re2/commit/2d39b703d02645076fead8fa409a1711f0e84381 made StringPiece convertible to std::string and RE2 internally appears to have been changed over to use such conversions.

However, if we made the same change RE2 did internally, that would break compatibility with older versions of RE2.

There appear to be 2 ways  to fix this:
1. Both the old StringPiece and the new string_view have data() and size() members with which we can construct a new std::string without care for which one we got.
2. We can just copy the string_ member we already have.

This change does 2 but 1 would be reasonable if the authors wish for that resolution.