### PR TITLE
Inherit C++ version number

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,12 +18,6 @@ cmake_minimum_required (VERSION 3.11)
 
 project (libphonenumber VERSION 8.13.0)
 
-# Pick the C++ standard to compile with.
-# Abseil currently supports C++11, C++14, and C++17.
-set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard used to compile this project")
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
-
 if (32BIT)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")

--- a/tools/cpp/CMakeLists.txt
+++ b/tools/cpp/CMakeLists.txt
@@ -16,11 +16,6 @@
 
 cmake_minimum_required (VERSION 3.11)
 
-# Pick the C++ standard to compile with.
-# Abseil currently supports C++11, C++14, and C++17.
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 project (generate_geocoding_data)
 
 set (


### PR DESCRIPTION
Do not overwrite binary settings like C++ version number.

For example this breaks [`ABSL_PROPAGATE_CXX_STD`](https://github.com/abseil/abseil-cpp/blob/efb035a5973b60d35ed8fcaa43e6736936a96173/CMakeLists.txt#L73-L78).