### PR TITLE
Update absl dependencies in CMakeLists.txt

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -433,7 +433,7 @@ include_directories ("src")
 # Collate dependencies
 #----------------------------------------------------------------
 
-set (LIBRARY_DEPS ${ICU_LIB} ${PROTOBUF_LIB} absl::node_hash_set absl::strings absl::synchronization)
+set (LIBRARY_DEPS ${ICU_LIB} ${PROTOBUF_LIB} absl::node_hash_set absl::strings absl::synchronization absl::log_internal_message absl::log_internal_check_op)
 
 if (USE_BOOST)
   list (APPEND LIBRARY_DEPS ${Boost_LIBRARIES})


### PR DESCRIPTION
Temporary fix for b/283987730 (failing build due to new protobuf having absl dependencies).

There is currently an issue with linking of Protobuf version 22.0 and newer.
This is caused by an added dependency to Abseil, and the transitive dependencies that are not propagated correctly.

This fix is working for Protobuf version 23.4 and newer. 
Approximately from Protobuf version 23.4, the find_package(protobuf) which uses the embedded FindProtobuf package from CMake, have been updated to know about the Abseil dependency.

This PR is adding some needed dependencies.