### PR TITLE
Use a singleton for ShortNumberInfo in PhoneExtractor::RunFocusedArena

### DIFF
--- a/cpp/src/phonenumbers/shortnumberinfo.cc
+++ b/cpp/src/phonenumbers/shortnumberinfo.cc
@@ -42,6 +42,7 @@ bool LoadCompiledInMetadata(PhoneMetadataCollection* metadata) {
   return true;
 }
 
+// Private constructor. Also takes care of initialisation.
 ShortNumberInfo::ShortNumberInfo()
     : phone_util_(*PhoneNumberUtil::GetInstance()),
       matcher_api_(new RegexBasedMatcher()),
@@ -400,6 +401,13 @@ bool ShortNumberInfo::IsSmsServiceForRegion(const PhoneNumber& number,
   return phone_metadata &&
          MatchesPossibleNumberAndNationalNumber(*matcher_api_, national_number,
              phone_metadata->sms_services());
+}
+
+// Public wrapper function to get a ShortNumberInfo instance.
+// static
+const ShortNumberInfo& ShortNumberInfo::GetInstance() {
+  static auto* const kInstance = new ShortNumberInfo();
+  return *kInstance;
 }
 
 }  // namespace phonenumbers

--- a/cpp/src/phonenumbers/shortnumberinfo.h
+++ b/cpp/src/phonenumbers/shortnumberinfo.h
@@ -44,9 +44,6 @@ class PhoneNumberUtil;
 
 class ShortNumberInfo {
  public:
-  ShortNumberInfo();
-  ~ShortNumberInfo();
-
   // Cost categories of short numbers.
   enum ShortNumberCost {
     TOLL_FREE,
@@ -176,7 +173,18 @@ class ShortNumberInfo {
       const PhoneNumber& number,
       const string& region_dialing_from) const;
 
+  // Gets a ShortNumberInfo instance to validate whether a short number is a
+  // possible number when dialed from a region, given the number in the form of
+  // a string, and the region where the number is dialed from.
+  //
+  // The ShortNumberInfo is implemented as a singleton. Therefore, calling
+  // GetInstance multiple times will only result in one instance being created.
+  static const ShortNumberInfo& GetInstance();
+
  private:
+  ShortNumberInfo();
+  ~ShortNumberInfo();
+
   const PhoneNumberUtil& phone_util_;
   const scoped_ptr<const MatcherApi> matcher_api_;
 

--- a/cpp/test/phonenumbers/shortnumberinfo_test.cc
+++ b/cpp/test/phonenumbers/shortnumberinfo_test.cc
@@ -42,12 +42,12 @@ class ShortNumberInfoTest : public testing::Test {
     return phone_number;
   }
 
-  ShortNumberInfoTest() : short_info_() {
-    PhoneNumberUtil::GetInstance()->SetLogger(new StdoutLogger());
+  ShortNumberInfoTest() : short_info_(ShortNumberInfo::GetInstance()) {
+   PhoneNumberUtil::GetInstance()->SetLogger(new StdoutLogger());
   }
 
   const PhoneNumberUtil phone_util_;
-  const ShortNumberInfo short_info_;
+  const ShortNumberInfo& short_info_;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(ShortNumberInfoTest);


### PR DESCRIPTION
This change is expected to reduce CPU usage by only initializing ShortNumberInfo once throughout the lifetime of the application. This pattern is already used in PhoneNumberUtil.