### PR TITLE
Update  phonenumberutil.format to return 'empty' instead of value "0".

### DIFF
--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -1275,14 +1275,12 @@ public class PhoneNumberUtil {
    * @return  the formatted phone number
    */
   public String format(PhoneNumber number, PhoneNumberFormat numberFormat) {
-    if (number.getNationalNumber() == 0 && number.hasRawInput()) {
+    if (number.getNationalNumber() == 0) {
       // Unparseable numbers that kept their raw input just use that.
       // This is the only case where a number can be formatted as E164 without a
       // leading '+' symbol (but the original number wasn't parseable anyway).
-      // TODO: Consider removing the 'if' above so that unparseable
-      // strings without raw input format to the empty string instead of "+00".
       String rawInput = number.getRawInput();
-      if (rawInput.length() > 0) {
+      if (rawInput.length() > 0 || !number.hasCountryCode()) {
         return rawInput;
       }
     }


### PR DESCRIPTION
Below methods of phonenumberutil.format are currently returning '0' it should return 'empty'
1. phoneNumberUtil.format(new PhoneNumber(), PhoneNumberUtil.PhoneNumberFormat.NATIONAL)
2. phoneNumberUtil.format(new PhoneNumber(), PhoneNumberUtil.PhoneNumberFormat.INTERNATIONAL)