### PR TITLE
feat: add Lebara to list of carriers in germany

### DIFF
--- a/resources/carrier/en/49.txt
+++ b/resources/carrier/en/49.txt
@@ -51,3 +51,5 @@
 49177|Eplus
 49178|Eplus
 49179|O2
+4915510|Lebara
+4915511|Lebara


### PR DESCRIPTION
While looking at a list of MCC/MNCs (https://www.mcc-mnc.com/) I noticed that Lebara is missing on your list of carriers.

This PR aims to resolve it by adding the 2 prefixes used by Lebara (https://www.teltarif.de/netzwechsel-lebara/news/88014.html) to the list.