### PR TITLE
E164 parsing issue with +3758105261733 (national only number formatted as E.164).

### DIFF
--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -3020,9 +3020,12 @@ public class PhoneNumberUtil {
       if (transformRule == null || transformRule.length() == 0
           || prefixMatcher.group(numOfGroups) == null) {
         // If the original number was viable, and the resultant number is not, we return.
-        if (isViableOriginalNumber
+        if ((isViableOriginalNumber
             && !matcherApi.matchNationalNumber(
-                number.substring(prefixMatcher.end()), generalDesc, false)) {
+                number.substring(prefixMatcher.end()), generalDesc, false))|| 
+                (getNumberTypeHelper(number.toString(), metadata) != PhoneNumberType.UNKNOWN
+                && getNumberTypeHelper(number.substring(prefixMatcher.end()), metadata)
+                    == PhoneNumberType.UNKNOWN)) {
           return false;
         }
         if (carrierCode != null && numOfGroups > 0 && prefixMatcher.group(numOfGroups) != null) {

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
@@ -1866,6 +1866,21 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
     assertEquals("Should have had no change - after stripping, it wouldn't have matched "
         + "the national rule.",
         strippedNumber, numberToStrip.toString());
+    metadata.setNationalPrefixForParsing("0|80?");
+    metadata.setPremiumRate(
+        metadata
+            .getGeneralDescBuilder()
+            .setNationalNumberPattern("(?:810|902)\d{7}"));
+    metadata.setPremiumRate(metadata.getGeneralDescBuilder().addPossibleLength(10));
+    numberToStrip = new StringBuilder("8105261733");
+    strippedNumber = "8105261733";
+    assertFalse(
+        phoneUtil.maybeStripNationalPrefixAndCarrierCode(numberToStrip, metadata.build(), null));
+    assertEquals(
+        "Should have had no change - after stripping, it wouldn't have matched "
+            + "the national rule.",
+        strippedNumber,
+        numberToStrip.toString());
     // Test extracting carrier selection code.
     metadata.setNationalPrefixForParsing("0(81)?");
     numberToStrip = new StringBuilder("08122123456");

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
@@ -1843,6 +1843,9 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
     metadata
         .getGeneralDescBuilder()
         .setNationalNumberPattern("\\d{4,8}");
+    metadata
+        .getGeneralDescBuilder()
+        .addPossibleLength(6);
     StringBuilder numberToStrip = new StringBuilder("34356778");
     String strippedNumber = "356778";
     assertTrue(phoneUtil.maybeStripNationalPrefixAndCarrierCode(numberToStrip, metadata.build(), null));
@@ -1870,7 +1873,7 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
     metadata.setPremiumRate(
         metadata
             .getGeneralDescBuilder()
-            .setNationalNumberPattern("(?:810|902)\d{7}"));
+            .setNationalNumberPattern("(?:810|902)\\d{7}"));
     metadata.setPremiumRate(metadata.getGeneralDescBuilder().addPossibleLength(10));
     numberToStrip = new StringBuilder("8105261733");
     strippedNumber = "8105261733";


### PR DESCRIPTION
 the number is valid with '8' but while parsing '8' is being removed because it's listed as a national prefix (prefixes for BY are "8,0,80").. To fix this issue first by checking the validity of the  unmodified number if it is valid we should not remove the national prefix.