### PR TITLE
Mandlil patch 2

### DIFF
--- a/cpp/src/phonenumbers/asyoutypeformatter.h
+++ b/cpp/src/phonenumbers/asyoutypeformatter.h
@@ -52,6 +52,11 @@ class PhoneNumberUtil;
 
 class AsYouTypeFormatter {
  public:
+
+ // This type is neither copyable nor movable.
+  AsYouTypeFormatter(const AsYouTypeFormatter&) = delete;
+  AsYouTypeFormatter& operator=(const AsYouTypeFormatter&) = delete;
+
   ~AsYouTypeFormatter() {}
 
   // Formats a phone number on-the-fly as each digit is entered.
@@ -233,7 +238,7 @@ class AsYouTypeFormatter {
 
   // Disallow copy and assign since this class uses RegExpCache which can't be
   // copied.
-  DISALLOW_COPY_AND_ASSIGN(AsYouTypeFormatter);
+  
 };
 
 }  // namespace phonenumbers

--- a/cpp/src/phonenumbers/base/synchronization/lock_posix.h
+++ b/cpp/src/phonenumbers/base/synchronization/lock_posix.h
@@ -33,6 +33,10 @@ class Lock {
     DCHECK_EQ(0, ret);
   }
 
+  // This type is neither copyable nor movable.
+  Lock(const Lock&) = delete;
+  Lock& operator=(const Lock&) = delete;
+
   ~Lock() {
     const int ret = pthread_mutex_destroy(&mutex_);
     (void) ret;
@@ -52,8 +56,6 @@ class Lock {
   }
 
  private:
-  DISALLOW_COPY_AND_ASSIGN(Lock);
-
   mutable pthread_mutex_t mutex_;
 };
 

--- a/cpp/src/phonenumbers/geocoding/area_code_map.h
+++ b/cpp/src/phonenumbers/geocoding/area_code_map.h
@@ -17,6 +17,7 @@
 #ifndef I18N_PHONENUMBERS_AREA_CODE_MAP_H_
 #define I18N_PHONENUMBERS_AREA_CODE_MAP_H_
 
+#include <cstdint>
 #include <map>
 #include <string>
 
@@ -39,6 +40,11 @@ struct PrefixDescriptions;
 class AreaCodeMap {
  public:
   AreaCodeMap();
+
+  // This type is neither copyable nor movable.
+  AreaCodeMap(const AreaCodeMap&) = delete;
+  AreaCodeMap& operator=(const AreaCodeMap&) = delete;
+
   ~AreaCodeMap();
 
   // Returns the description of the geographical area the number corresponds
@@ -61,12 +67,10 @@ class AreaCodeMap {
   // (inclusive). Returns the position if {@code value} is found; otherwise,
   // returns the position which has the largest value that is less than value.
   // This means if value is the smallest, -1 will be returned.
-  int BinarySearch(int start, int end, int64 value) const;
+  int BinarySearch(int start, int end, int64_t value) const;
 
   const PhoneNumberUtil& phone_util_;
   scoped_ptr<const DefaultMapStorage> storage_;
-
-  DISALLOW_COPY_AND_ASSIGN(AreaCodeMap);
 };
 
 }  // namespace phonenumbers

--- a/cpp/src/phonenumbers/geocoding/default_map_storage.h
+++ b/cpp/src/phonenumbers/geocoding/default_map_storage.h
@@ -19,6 +19,7 @@
 #ifndef I18N_PHONENUMBERS_DEFAULT_MAP_STORAGE_H_
 #define I18N_PHONENUMBERS_DEFAULT_MAP_STORAGE_H_
 
+#include <cstdint>
 #include "phonenumbers/base/basictypes.h"
 
 namespace i18n {
@@ -33,10 +34,15 @@ struct PrefixDescriptions;
 class DefaultMapStorage {
  public:
   DefaultMapStorage();
+
+   // This type is neither copyable nor movable.
+  DefaultMapStorage(const DefaultMapStorage&) = delete;
+  DefaultMapStorage& operator=(const DefaultMapStorage&) = delete;
+
   virtual ~DefaultMapStorage();
 
   // Returns the phone number prefix located at the provided index.
-  int32 GetPrefix(int index) const;
+  int32_t GetPrefix(int index) const;
 
   // Gets the description corresponding to the phone number prefix located
   // at the provided index. If the description is not available in the current
@@ -59,15 +65,13 @@ class DefaultMapStorage {
 
  private:
   // Sorted sequence of phone number prefixes.
-  const int32* prefixes_;
+  const int32_t* prefixes_;
   int prefixes_size_;
   // Sequence of prefix descriptions, in the same order than prefixes_.
   const char** descriptions_;
   // Sequence of unique possible lengths in ascending order.
-  const int32* possible_lengths_;
+  const int32_t* possible_lengths_;
   int possible_lengths_size_;
-
-  DISALLOW_COPY_AND_ASSIGN(DefaultMapStorage);
 };
 
 }  // namespace phonenumbers

--- a/cpp/src/phonenumbers/geocoding/mapping_file_provider.h
+++ b/cpp/src/phonenumbers/geocoding/mapping_file_provider.h
@@ -44,6 +44,10 @@ class MappingFileProvider {
                       int country_calling_code_size,
                       country_languages_getter get_country_languages);
 
+  // This type is neither copyable nor movable.
+  MappingFileProvider(const MappingFileProvider&) = delete;
+  MappingFileProvider& operator=(const MappingFileProvider&) = delete;
+
   // Returns the name of the file that contains the mapping data for the
   // country_calling_code in the language specified, or an empty string if no
   // such file can be found.
@@ -68,8 +72,6 @@ class MappingFileProvider {
   const int* const country_calling_codes_;
   const int country_calling_codes_size_;
   const country_languages_getter get_country_languages_;
-
-  DISALLOW_COPY_AND_ASSIGN(MappingFileProvider);
 };
 
 }  // namespace phonenumbers

--- a/cpp/src/phonenumbers/geocoding/phonenumber_offline_geocoder.h
+++ b/cpp/src/phonenumbers/geocoding/phonenumber_offline_geocoder.h
@@ -61,6 +61,11 @@ class PhoneNumberOfflineGeocoder {
       int prefix_language_code_pairs_size,
       prefix_descriptions_getter get_prefix_descriptions);
 
+  // This type is neither copyable nor movable.
+  PhoneNumberOfflineGeocoder(const PhoneNumberOfflineGeocoder&) = delete;
+  PhoneNumberOfflineGeocoder& operator=(const PhoneNumberOfflineGeocoder&) =
+      delete;
+
   virtual ~PhoneNumberOfflineGeocoder();
 
   // Returns a text description for the given phone number, in the language
@@ -164,7 +169,6 @@ class PhoneNumberOfflineGeocoder {
   // phone prefix map that has been loaded.
   mutable absl::Mutex mu_;
   mutable AreaCodeMaps available_maps_ ABSL_GUARDED_BY(mu_);
-  DISALLOW_COPY_AND_ASSIGN(PhoneNumberOfflineGeocoder);
 };
 
 }  // namespace phonenumbers

--- a/cpp/src/phonenumbers/phonenumbermatch.h
+++ b/cpp/src/phonenumbers/phonenumbermatch.h
@@ -74,6 +74,10 @@ class PhoneNumberMatch {
   // Default constructor.
   PhoneNumberMatch();
 
+  // This type is neither copyable nor movable.
+  PhoneNumberMatch(const PhoneNumberMatch&) = delete;
+  PhoneNumberMatch& operator=(const PhoneNumberMatch&) = delete;
+
   ~PhoneNumberMatch() {}
 
   // Returns the phone number matched by the receiver.
@@ -116,7 +120,6 @@ class PhoneNumberMatch {
   // The matched phone number.
   PhoneNumber number_;
 
-  DISALLOW_COPY_AND_ASSIGN(PhoneNumberMatch);
 };
 
 }  // namespace phonenumbers

--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -842,8 +842,10 @@ class PhoneNumberRegExpsAndMappings {
     InitializeMapsAndSets();
   }
 
- private:
-  DISALLOW_COPY_AND_ASSIGN(PhoneNumberRegExpsAndMappings);
+ // This type is neither copyable nor movable.
+  PhoneNumberRegExpsAndMappings(const PhoneNumberRegExpsAndMappings&) = delete;
+  PhoneNumberRegExpsAndMappings& operator=(
+      const PhoneNumberRegExpsAndMappings&) = delete;
 };
 
 // Private constructor. Also takes care of initialisation.

--- a/cpp/src/phonenumbers/phonenumberutil.h
+++ b/cpp/src/phonenumbers/phonenumberutil.h
@@ -68,6 +68,10 @@ class PhoneNumberUtil : public Singleton<PhoneNumberUtil> {
   friend class Singleton<PhoneNumberUtil>;
 
  public:
+  // This type is neither copyable nor movable.
+  PhoneNumberUtil(const PhoneNumberUtil&) = delete;
+  PhoneNumberUtil& operator=(const PhoneNumberUtil&) = delete;
+
   ~PhoneNumberUtil();
   static const char kRegionCodeForNonGeoEntity[];
 
@@ -970,7 +974,6 @@ class PhoneNumberUtil : public Singleton<PhoneNumberUtil> {
   bool IsShorterThanPossibleNormalNumber(const PhoneMetadata* country_metadata,
                                          const string& number) const;
 
-  DISALLOW_COPY_AND_ASSIGN(PhoneNumberUtil);
 };
 
 }  // namespace phonenumbers

--- a/cpp/src/phonenumbers/regex_based_matcher.h
+++ b/cpp/src/phonenumbers/regex_based_matcher.h
@@ -35,6 +35,11 @@ class RegExpCache;
 class RegexBasedMatcher : public MatcherApi {
  public:
   RegexBasedMatcher();
+
+  // This type is neither copyable nor movable.
+  RegexBasedMatcher(const RegexBasedMatcher&) = delete;
+  RegexBasedMatcher& operator=(const RegexBasedMatcher&) = delete;
+
   ~RegexBasedMatcher();
 
   bool MatchNationalNumber(const string& number,
@@ -48,7 +53,6 @@ class RegexBasedMatcher : public MatcherApi {
   const scoped_ptr<const AbstractRegExpFactory> regexp_factory_;
   const scoped_ptr<RegExpCache> regexp_cache_;
 
-  DISALLOW_COPY_AND_ASSIGN(RegexBasedMatcher);
 };
 
 }  // namespace phonenumbers

--- a/cpp/src/phonenumbers/regexp_adapter_icu.cc
+++ b/cpp/src/phonenumbers/regexp_adapter_icu.cc
@@ -69,6 +69,11 @@ class IcuRegExpInput : public RegExpInput {
       : utf8_input_(Utf8StringToUnicodeString(utf8_input)),
         position_(0) {}
 
+
+  // This type is neither copyable nor movable.
+  IcuRegExpInput(const IcuRegExpInput&) = delete;
+  IcuRegExpInput& operator=(const IcuRegExpInput&) = delete;
+
   virtual ~IcuRegExpInput() {}
 
   virtual string ToString() const {
@@ -95,7 +100,6 @@ class IcuRegExpInput : public RegExpInput {
   UnicodeString utf8_input_;
   int position_;
 
-  DISALLOW_COPY_AND_ASSIGN(IcuRegExpInput);
 };
 
 // ICU implementation of the RegExp abstract class.
@@ -112,6 +116,10 @@ class IcuRegExp : public RegExp {
       utf8_regexp_.reset(NULL);
     }
   }
+
+  // This type is neither copyable nor movable.
+  IcuRegExp(const IcuRegExp&) = delete;
+  IcuRegExp& operator=(const IcuRegExp&) = delete; 
 
   virtual ~IcuRegExp() {}
 
@@ -223,8 +231,6 @@ class IcuRegExp : public RegExp {
 
  private:
   scoped_ptr<RegexPattern> utf8_regexp_;
-
-  DISALLOW_COPY_AND_ASSIGN(IcuRegExp);
 };
 
 RegExpInput* ICURegExpFactory::CreateInput(const string& utf8_input) const {

--- a/cpp/src/phonenumbers/regexp_cache.h
+++ b/cpp/src/phonenumbers/regexp_cache.h
@@ -59,6 +59,10 @@ class RegExpCache {
  public:
   explicit RegExpCache(const AbstractRegExpFactory& regexp_factory,
                        size_t min_items);
+  // This type is neither copyable nor movable.
+  RegExpCache(const RegExpCache&) = delete;
+  RegExpCache& operator=(const RegExpCache&) = delete;
+
   ~RegExpCache();
 
   const RegExp& GetRegExp(const string& pattern);
@@ -68,7 +72,6 @@ class RegExpCache {
   Lock lock_;  // protects cache_impl_
   scoped_ptr<CacheImpl> cache_impl_;  // protected by lock_
   friend class RegExpCacheTest_CacheConstructor_Test;
-  DISALLOW_COPY_AND_ASSIGN(RegExpCache);
 };
 
 }  // namespace phonenumbers

--- a/cpp/src/phonenumbers/shortnumberinfo.h
+++ b/cpp/src/phonenumbers/shortnumberinfo.h
@@ -45,6 +45,11 @@ class PhoneNumberUtil;
 class ShortNumberInfo {
  public:
   ShortNumberInfo();
+
+  // This type is neither copyable nor movable.
+  ShortNumberInfo(const ShortNumberInfo&) = delete;
+  ShortNumberInfo& operator=(const ShortNumberInfo&) = delete;
+
   ~ShortNumberInfo();
 
   // Cost categories of short numbers.
@@ -206,8 +211,6 @@ class ShortNumberInfo {
   bool MatchesEmergencyNumberHelper(const string& number,
                                     const string& region_code,
                                     bool allow_prefix_match) const;
-
-  DISALLOW_COPY_AND_ASSIGN(ShortNumberInfo);
 };
 
 }  // namespace phonenumbers

--- a/cpp/test/phonenumbers/asyoutypeformatter_test.cc
+++ b/cpp/test/phonenumbers/asyoutypeformatter_test.cc
@@ -34,6 +34,11 @@ namespace phonenumbers {
 class PhoneMetadata;
 
 class AsYouTypeFormatterTest : public testing::Test {
+ public:
+  // This type is neither copyable nor movable.
+  AsYouTypeFormatterTest(const AsYouTypeFormatterTest&) = delete;
+  AsYouTypeFormatterTest& operator=(const AsYouTypeFormatterTest&) = delete;
+
  protected:
   AsYouTypeFormatterTest() : phone_util_(*PhoneNumberUtil::GetInstance()) {
     PhoneNumberUtil::GetInstance()->SetLogger(new StdoutLogger());
@@ -55,8 +60,6 @@ class AsYouTypeFormatterTest : public testing::Test {
   scoped_ptr<AsYouTypeFormatter> formatter_;
   string result_;
 
- private:
-  DISALLOW_COPY_AND_ASSIGN(AsYouTypeFormatterTest);
 };
 
 TEST_F(AsYouTypeFormatterTest, ConvertUnicodeStringPosition) {

--- a/cpp/test/phonenumbers/phonenumberutil_test.cc
+++ b/cpp/test/phonenumbers/phonenumberutil_test.cc
@@ -49,6 +49,11 @@ using google::protobuf::RepeatedPtrField;
 static const int kInvalidCountryCode = 2;
 
 class PhoneNumberUtilTest : public testing::Test {
+ public:
+  // This type is neither copyable nor movable.
+  PhoneNumberUtilTest(const PhoneNumberUtilTest&) = delete;
+  PhoneNumberUtilTest& operator=(const PhoneNumberUtilTest&) = delete;
+
  protected:
   PhoneNumberUtilTest() : phone_util_(*PhoneNumberUtil::GetInstance()) {
     PhoneNumberUtil::GetInstance()->SetLogger(new StdoutLogger());
@@ -120,8 +125,6 @@ class PhoneNumberUtilTest : public testing::Test {
 
   const PhoneNumberUtil& phone_util_;
 
- private:
-  DISALLOW_COPY_AND_ASSIGN(PhoneNumberUtilTest);
 };
 
 TEST_F(PhoneNumberUtilTest, ContainsOnlyValidDigits) {

--- a/cpp/test/phonenumbers/shortnumberinfo_test.cc
+++ b/cpp/test/phonenumbers/shortnumberinfo_test.cc
@@ -31,6 +31,11 @@
 namespace i18n {
 namespace phonenumbers {
 class ShortNumberInfoTest : public testing::Test {
+ public:
+  // This type is neither copyable nor movable.
+  ShortNumberInfoTest(const ShortNumberInfoTest&) = delete;
+  ShortNumberInfoTest& operator=(const ShortNumberInfoTest&) = delete;
+
  protected:
   PhoneNumber ParseNumberForTesting(const string& number,
                                     const string& region_code) {
@@ -49,8 +54,6 @@ class ShortNumberInfoTest : public testing::Test {
   const PhoneNumberUtil phone_util_;
   const ShortNumberInfo short_info_;
 
- private:
-  DISALLOW_COPY_AND_ASSIGN(ShortNumberInfoTest);
 };
 
 TEST_F(ShortNumberInfoTest, IsPossibleShortNumber) {


### PR DESCRIPTION
Remove uses of the deprecated DISALLOW_COPY_AND_ASSIGN in favor of explicitly deleted constructors and assignment operators.