### PR TITLE
Update Danish number plan according to the SDFI

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -8663,6 +8663,7 @@
     <!-- http://www.dba.erhvervsstyrelsen.dk/numbering-lists -->
     <!-- https://en.wikipedia.org/wiki/Telephone_numbers_in_Denmark -->
     <!-- https://www.itu.int/oth/T0202000038/en -->
+    <!-- https://sdfi.dk/Media/637925268968845027/nummerplan_2020_farver.pdf -->
     <territory id="DK" countryCode="45" internationalPrefix="00" mobileNumberPortableRegion="true">
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{2})">
@@ -8673,28 +8674,78 @@
       <generalDesc>
         <nationalNumberPattern>[2-9]\d{7}</nationalNumberPattern>
       </generalDesc>
-      <!-- Note that "mainly mobile" and "mainly fixed-line" are put under both number types to be
-           safe. -->
+      <!-- Note that DK has ranges that are fixed lines but are currently
+          designated to mobile numbers as stated by
+          https://sdfi.dk/Media/637925268968845027/nummerplan_2020_farver.pdf
+          In number series marked with (!) the following series of numbers
+          are allocated primarily for mobile communication instead of landline
+          communication
+        -->
       <fixedLine>
         <possibleLengths national="8"/>
         <exampleNumber>32123456</exampleNumber>
         <nationalNumberPattern>
           (?:
-            [2-7]\d|
-            8[126-9]|
-            9[1-46-9]
+            3[2-689]|
+            4[3-9]|
+            5[4-9]|
+            6[2-69]|
+            7[02-9]|
+            8[26-9]|
+            9[6-9]
           )\d{6}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>32123456</exampleNumber>
+        <!-- Note that DK has ranges that are fixed lines but are currently
+          designated to mobile numbers as stated by
+          https://sdfi.dk/Media/637925268968845027/nummerplan_2020_farver.pdf
+          In number series marked with (!) the following series of numbers
+          are allocated primarily for mobile communication instead of landline
+          communication
+
+          These ranges have been added to the mobile number pattern but are NOT
+          excluded by the fixed line section.
+        -->
         <nationalNumberPattern>
           (?:
-            [2-7]\d|
-            8[126-9]|
-            9[1-46-9]
-          )\d{6}
+            2[0-9]|
+            3[0-1]|
+            4[0-2]|
+            5[0-3]|
+            6[0-1]|
+            71|
+            81|
+            9[1-3]|
+          )\d{6}|
+          (?:
+            34[24-9]|
+            35[679]|
+            36[256]|
+            389|
+            398|
+            431|
+            441|
+            46[268]|
+            47[2468]|
+            48[5689]|
+            49[3-689]|
+            54[235]|
+            55[126]|
+            57[1-479]|
+            58[4679]|
+            59[78]|
+            62[79]|
+            64[19]|
+            658|
+            66[2-57]|
+            69[2-47]|
+            77[12]|
+            78[235689]|
+            82[679]
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
       <tollFree>


### PR DESCRIPTION
The information can be found via:
https://eng.sdfi.dk/digital-infrastructure/telecom/numbering

The link to the number plan is this:
* https://sdfi.dk/Media/637925268968845027/nummerplan_2020_farver.pdf

Notable exceptions are in landline segments where chunks are allocated to mobile numbers:

- In number series marked with (!) the following number series are primarily allocated for mobile communication instead of landline communication: 342, 344-349, 356-357, 359, 362, 365-366, 389, 398, 431, 441, 462, 466, 468, 472, 474, 476, 478, 485-486, 488-489, 493-496, 498-499, 542-543, 545, 551-552, 556, 571-574, 577, 579, 584, 586-587, 589, 597-598, 627, 629, 641, 649, 658, 662-665, 667, 692-694, 697, 771-772, 782-783, 785-786, 788-789, 826-827 and 829.

These exceptions are listed as mobile numbers in the XML and are still present in the fixed-line configuration.

The Danish should start to indicate when these allocations are finalized.

=== Google contributions requirements:

*   Country: DK
*   Example number(s) and/or range(s): Any number
*   Number type ("fixed-line", "mobile", "short code", etc.): fixed-line, mobile
*   Where or whom did you get the number(s) from: https://eng.sdfi.dk/digital-infrastructure/telecom/numbering -> https://sdfi.dk/Media/637925268968845027/nummerplan_2020_farver.pdf
*   Authoritative evidence (e.g. national numbering plan, operator announcement): https://sdfi.dk/Media/637925268968845027/nummerplan_2020_farver.pdf
*   Link from demo (http://libphonenumber.appspot.com) showing error: No errors, just downstream issues where numbers are only geographic while a number plan exists with mobile, fixed-line distinction (albeit somewhat blurry in certain cases).