### PR TITLE
Area code information lost for all MX numbers in v8.13.38 metadata update

### DIFF
--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -619,6 +619,7 @@ class PhoneNumberRegExpsAndMappings {
     }
 
     mobile_token_mappings_.insert(std::make_pair(54, '9'));
+    countries_without_national_prefix_with_area_codes_.insert(52);  // Mexico
     geo_mobile_countries_without_mobile_area_codes_.insert(86);  // China
     geo_mobile_countries_.insert(52);  // Mexico
     geo_mobile_countries_.insert(54);  // Argentina
@@ -695,6 +696,10 @@ class PhoneNumberRegExpsAndMappings {
   // that are geographically assigned: this carrier indicator is not considered
   // to be an area code.
   std::set<int> geo_mobile_countries_without_mobile_area_codes_;
+
+  // Set of country codes that doesn't have national prefix, but it has area
+  // codes.
+  std::set<int> countries_without_national_prefix_with_area_codes_;
 
   // Set of country calling codes that have geographically assigned mobile
   // numbers. This may not be complete; we add calling codes case by case, as we
@@ -795,6 +800,7 @@ class PhoneNumberRegExpsAndMappings {
         alpha_phone_mappings_(),
         all_plus_number_grouping_symbols_(),
         mobile_token_mappings_(),
+        countries_without_national_prefix_with_area_codes_(),
         geo_mobile_countries_without_mobile_area_codes_(),
         geo_mobile_countries_(),
         single_international_prefix_(regexp_factory_->CreateRegExp(
@@ -2676,15 +2682,22 @@ int PhoneNumberUtil::GetLengthOfGeographicalAreaCode(
   if (!metadata) {
     return 0;
   }
-  // If a country doesn't use a national prefix, and this number doesn't have an
-  // Italian leading zero, we assume it is a closed dialling plan with no area
-  // codes.
-  if (!metadata->has_national_prefix() && !number.italian_leading_zero()) {
-    return 0;
-  }
 
   PhoneNumberType type = GetNumberType(number);
   int country_calling_code = number.country_code();
+  
+  // If a country doesn't use a national prefix, and this number doesn't have an
+  // Italian leading zero, we assume it is a closed dialling plan with no area
+  // codes.
+  // Note:this is our general assumption, but there are exceptions which are
+  // tracked in COUNTRIES_WITHOUT_NATIONAL_PREFIX_WITH_AREA_CODES.
+  if (!metadata->has_national_prefix() && !number.italian_leading_zero() &&
+      reg_exps_->countries_without_national_prefix_with_area_codes_.find(
+          country_calling_code) !=
+          reg_exps_->countries_without_national_prefix_with_area_codes_.end()) {
+    return 0;
+  }
+
   if (type == PhoneNumberUtil::MOBILE &&
       reg_exps_->geo_mobile_countries_without_mobile_area_codes_.find(
           country_calling_code) !=

--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -2693,7 +2693,7 @@ int PhoneNumberUtil::GetLengthOfGeographicalAreaCode(
   // tracked in COUNTRIES_WITHOUT_NATIONAL_PREFIX_WITH_AREA_CODES.
   if (!metadata->has_national_prefix() && !number.italian_leading_zero() &&
       reg_exps_->countries_without_national_prefix_with_area_codes_.find(
-          country_calling_code) !=
+          country_calling_code) ==
           reg_exps_->countries_without_national_prefix_with_area_codes_.end()) {
     return 0;
   }

--- a/cpp/test/phonenumbers/phonenumberutil_test.cc
+++ b/cpp/test/phonenumbers/phonenumberutil_test.cc
@@ -1472,6 +1472,12 @@ TEST_F(PhoneNumberUtilTest, GetLengthOfGeographicalAreaCode) {
   number.set_italian_leading_zero(true);
   EXPECT_EQ(2, phone_util_.GetLengthOfGeographicalAreaCode(number));
 
+  // Mexico numbers - there is no national prefix, but it still has an area
+  // code.
+  number.set_country_code(52);
+  number.set_national_number(uint64_t{3312345678});
+  EXPECT_EQ(2, phone_util_.GetLengthOfGeographicalAreaCode(number));
+
   // Google Singapore. Singapore has no area code and no national prefix.
   number.set_country_code(65);
   number.set_national_number(uint64{65218000});

--- a/cpp/test/phonenumbers/phonenumberutil_test.cc
+++ b/cpp/test/phonenumbers/phonenumberutil_test.cc
@@ -1465,17 +1465,17 @@ TEST_F(PhoneNumberUtilTest, GetLengthOfGeographicalAreaCode) {
   number.set_national_number(uint64{293744000});
   EXPECT_EQ(1, phone_util_.GetLengthOfGeographicalAreaCode(number));
 
+  // Mexico numbers - there is no national prefix, but it still has an area
+  // code.
+  number.set_country_code(52);
+  number.set_national_number(uint64_t{3312345678});
+  EXPECT_EQ(2, phone_util_.GetLengthOfGeographicalAreaCode(number));
+
   // Italian numbers - there is no national prefix, but it still has an area
   // code.
   number.set_country_code(39);
   number.set_national_number(uint64{236618300});
   number.set_italian_leading_zero(true);
-  EXPECT_EQ(2, phone_util_.GetLengthOfGeographicalAreaCode(number));
-
-  // Mexico numbers - there is no national prefix, but it still has an area
-  // code.
-  number.set_country_code(52);
-  number.set_national_number(uint64_t{3312345678});
   EXPECT_EQ(2, phone_util_.GetLengthOfGeographicalAreaCode(number));
 
   // Google Singapore. Singapore has no area code and no national prefix.

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -85,6 +85,10 @@ public class PhoneNumberUtil {
   // considered to be an area code.
   private static final Set<Integer> GEO_MOBILE_COUNTRIES_WITHOUT_MOBILE_AREA_CODES;
 
+  // Set of country codes that doesn't have national prefix, but it has area codes.
+  private static final ImmutableSet<Integer> COUNTRIES_WITHOUT_NATIONAL_PREFIX_WITH_AREA_CODES =
+      ImmutableSet.of(52);
+
   // Set of country calling codes that have geographically assigned mobile numbers. This may not be
   // complete; we add calling codes case by case, as we find geographical mobile numbers or hear
   // from user reports. Note that countries like the US, where we can't distinguish between
@@ -895,7 +899,10 @@ public class PhoneNumberUtil {
     }
     // If a country doesn't use a national prefix, and this number doesn't have an Italian leading
     // zero, we assume it is a closed dialling plan with no area codes.
-    if (!metadata.hasNationalPrefix() && !number.isItalianLeadingZero()) {
+    // Note:this is our general assumption, but there are exceptions which are tracked in
+    // COUNTRIES_WITHOUT_NATIONAL_PREFIX_WITH_AREA_CODES.
+    if (!metadata.hasNationalPrefix() && !number.isItalianLeadingZero() 
+    && !COUNTRIES_WITHOUT_NATIONAL_PREFIX_WITH_AREA_CODES.contains(countryCallingCode)) {
       return 0;
     }
 

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -86,8 +86,7 @@ public class PhoneNumberUtil {
   private static final Set<Integer> GEO_MOBILE_COUNTRIES_WITHOUT_MOBILE_AREA_CODES;
 
   // Set of country codes that doesn't have national prefix, but it has area codes.
-  private static final ImmutableSet<Integer> COUNTRIES_WITHOUT_NATIONAL_PREFIX_WITH_AREA_CODES =
-      ImmutableSet.of(52);
+  private static final Set<Integer> COUNTRIES_WITHOUT_NATIONAL_PREFIX_WITH_AREA_CODES;
 
   // Set of country calling codes that have geographically assigned mobile numbers. This may not be
   // complete; we add calling codes case by case, as we find geographical mobile numbers or hear
@@ -130,6 +129,11 @@ public class PhoneNumberUtil {
     geoMobileCountriesWithoutMobileAreaCodes.add(86);  // China
     GEO_MOBILE_COUNTRIES_WITHOUT_MOBILE_AREA_CODES =
         Collections.unmodifiableSet(geoMobileCountriesWithoutMobileAreaCodes);
+
+    HashSet<Integer> countriesWithoutNationalPrefixWithAreaCodes = new HashSet<>();
+    countriesWithoutNationalPrefixWithAreaCodes.add(52);  // Mexico
+    COUNTRIES_WITHOUT_NATIONAL_PREFIX_WITH_AREA_CODES = 
+    		Collections.unmodifiableSet(countriesWithoutNationalPrefixWithAreaCodes);
 
     HashSet<Integer> geoMobileCountries = new HashSet<>();
     geoMobileCountries.add(52);  // Mexico
@@ -897,6 +901,9 @@ public class PhoneNumberUtil {
     if (metadata == null) {
       return 0;
     }
+
+    PhoneNumberType type = getNumberType(number);
+    int countryCallingCode = number.getCountryCode();
     // If a country doesn't use a national prefix, and this number doesn't have an Italian leading
     // zero, we assume it is a closed dialling plan with no area codes.
     // Note:this is our general assumption, but there are exceptions which are tracked in
@@ -906,8 +913,6 @@ public class PhoneNumberUtil {
       return 0;
     }
 
-    PhoneNumberType type = getNumberType(number);
-    int countryCallingCode = number.getCountryCode();
     if (type == PhoneNumberType.MOBILE
         // Note this is a rough heuristic; it doesn't cover Indonesia well, for example, where area
         // codes are present for some mobile phones but not for others. We have no better way of

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
@@ -309,6 +309,9 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
     // Italian numbers - there is no national prefix, but it still has an area code.
     assertEquals(2, phoneUtil.getLengthOfGeographicalAreaCode(IT_NUMBER));
 
+    // Mexico numbers - there is no national prefix, but it still has an area code.
+    assertEquals(2, phoneUtil.getLengthOfGeographicalAreaCode(MX_NUMBER1));
+
     // Google Singapore. Singapore has no area code and no national prefix.
     assertEquals(0, phoneUtil.getLengthOfGeographicalAreaCode(SG_NUMBER));
 


### PR DESCRIPTION
After deleting the dialing tokens (01/02/044/045/1), the national prefix becomes empty so the condition is failing and returns 0.