### PR TITLE
Add support for Japan 060 mobile prefix

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -17369,7 +17369,7 @@
           <format>$1-$2-$3</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[257-9]</leadingDigits>
+          <leadingDigits>[25-9]</leadingDigits>
           <format>$1-$2-$3</format>
         </numberFormat>
         <numberFormat pattern="(\d{4})(\d{3})(\d{3,4})">
@@ -17475,7 +17475,7 @@
       <mobile>
         <possibleLengths national="10"/>
         <exampleNumber>9012345678</exampleNumber>
-        <nationalNumberPattern>[7-9]0[1-9]\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>[6-9]0[1-9]\d{7}</nationalNumberPattern>
       </mobile>
       <pager>
         <possibleLengths national="10"/>


### PR DESCRIPTION
I'm sorry, but I don't know how to contribute to this open-source project, and this is my first time submitting code to an open-source project. I encountered this issue at work, where Japan will start using phone numbers with the prefix 060 in a month. However, I found that this library does not support this, and I want to improve this situation. Please let me know if there are other parts that need to be modified beyond the relevant code I found.

[電気通信番号計画の一部変更等に関する意見募集](https://www.soumu.go.jp/menu_news/s-news/01kiban06_02000116.html)

I apologize for not thoroughly reading the documentation and causing you trouble with this PR. I have filed an issue, and I will close this PR.