### PR TITLE
Update PhoneNumberMetadata.xml

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -194,79 +194,77 @@
       </premiumRate>
     </territory>
 
-    <!-- United Arab Emirates (AE) -->
-    <!-- http://www.itu.int/oth/T02020000DC/en -->
-    <territory id="AE" countryCode="971" internationalPrefix="00" nationalPrefix="0">
-      <availableFormats>
-        <numberFormat pattern="(\d{3})(\d{2,9})">
-          <leadingDigits>
-            60|
-            8
-          </leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
-        <numberFormat pattern="(\d)(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            [236]|
-            [479][2-8]
-          </leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d)(\d{5})">
-          <leadingDigits>[479]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>5</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
-      </availableFormats>
-      <generalDesc>
-        <nationalNumberPattern>
-          (?:
-            [4-7]\d|
-            9[0-689]
-          )\d{7}|
-          800\d{2,9}|
-          [2-4679]\d{7}
-        </nationalNumberPattern>
-      </generalDesc>
-      <fixedLine>
-        <possibleLengths national="8" localOnly="7"/>
-        <exampleNumber>22345678</exampleNumber>
-        <nationalNumberPattern>[2-4679][2-8]\d{6}</nationalNumberPattern>
-      </fixedLine>
-      <!-- Prefixes 54 and 58 are mentioned on Wikipedia,
-           https://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Arab_Emirates. -->
-      <mobile>
-        <possibleLengths national="9"/>
-        <exampleNumber>501234567</exampleNumber>
-        <nationalNumberPattern>5[024-68]\d{7}</nationalNumberPattern>
-      </mobile>
-      <tollFree>
-        <possibleLengths national="[5-12]"/>
-        <exampleNumber>800123456</exampleNumber>
-        <nationalNumberPattern>
-          400\d{6}|
-          800\d{2,9}
-        </nationalNumberPattern>
-      </tollFree>
-      <premiumRate>
-        <possibleLengths national="9"/>
-        <exampleNumber>900234567</exampleNumber>
-        <nationalNumberPattern>900[02]\d{5}</nationalNumberPattern>
-      </premiumRate>
-      <sharedCost>
-        <possibleLengths national="9"/>
-        <exampleNumber>700012345</exampleNumber>
-        <nationalNumberPattern>700[05]\d{5}</nationalNumberPattern>
-      </sharedCost>
-      <uan>
-        <possibleLengths national="9"/>
-        <exampleNumber>600212345</exampleNumber>
-        <nationalNumberPattern>600[25]\d{5}</nationalNumberPattern>
-      </uan>
-    </territory>
+<!-- United Arab Emirates (AE) -->
+<!-- http://www.itu.int/oth/T02020000DC/en -->
+<territory id="AE" countryCode="971" internationalPrefix="00" nationalPrefix="0">
+  <availableFormats>
+    <numberFormat pattern="(\d{3})(\d{2,9})">
+      <leadingDigits>
+        60|
+        8
+      </leadingDigits>
+      <format>$1 $2</format>
+    </numberFormat>
+    <numberFormat pattern="(\d)(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+      <leadingDigits>
+        [236]|
+        [479][2-8]
+      </leadingDigits>
+      <format>$1 $2 $3</format>
+    </numberFormat>
+    <numberFormat pattern="(\d{3})(\d)(\d{5})">
+      <leadingDigits>[479]</leadingDigits>
+      <format>$1 $2 $3</format>
+    </numberFormat>
+    <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+      <leadingDigits>5</leadingDigits>
+      <format>$1 $2 $3</format>
+    </numberFormat>
+  </availableFormats>
+  <generalDesc>
+    <nationalNumberPattern>
+      (?:
+        [4-7]\d|
+        9[0-689]
+      )\d{7}|
+      800\d{2,9}|
+      [2-4679]\d{7}
+    </nationalNumberPattern>
+  </generalDesc>
+  <fixedLine>
+    <possibleLengths national="8" localOnly="7"/>
+    <exampleNumber>22345678</exampleNumber>
+    <nationalNumberPattern>[2-4679][2-8]\d{6}</nationalNumberPattern>
+  </fixedLine>
+  <mobile>
+    <possibleLengths national="9"/>
+    <exampleNumber>501234567</exampleNumber>
+    <nationalNumberPattern>5[024-68]\d{7}|53\d{7}</nationalNumberPattern>
+  </mobile>
+  <tollFree>
+    <possibleLengths national="[5-12]"/>
+    <exampleNumber>800123456</exampleNumber>
+    <nationalNumberPattern>
+      400\d{6}|
+      800\d{2,9}
+    </nationalNumberPattern>
+  </tollFree>
+  <premiumRate>
+    <possibleLengths national="9"/>
+    <exampleNumber>900234567</exampleNumber>
+    <nationalNumberPattern>900[02]\d{5}</nationalNumberPattern>
+  </premiumRate>
+  <sharedCost>
+    <possibleLengths national="9"/>
+    <exampleNumber>700012345</exampleNumber>
+    <nationalNumberPattern>700[05]\d{5}</nationalNumberPattern>
+  </sharedCost>
+  <uan>
+    <possibleLengths national="9"/>
+    <exampleNumber>600212345</exampleNumber>
+    <nationalNumberPattern>600[25]\d{5}</nationalNumberPattern>
+  </uan>
+</territory>
 
     <!-- Afghanistan (AF) -->
     <!-- http://www.itu.int/oth/T0202000001/en -->


### PR DESCRIPTION
Added 97153 - Virgin Mobile UAE
Prefixes 53, 54, and 58 are mentioned on Wikipedia,
    https://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Arab_Emirates.