### PR TITLE
Fix build on osx

### DIFF
--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -2215,7 +2215,7 @@ PhoneNumberUtil::ErrorType PhoneNumberUtil::BuildNationalNumberForParsing(
       // Additional parameters might follow the phone context. If so, we will
       // remove them here because the parameters after phone context are not
       // important for parsing the phone number.
-      StrAppend(national_number, phone_context.value());
+      StrAppend(national_number, StringHolder(phone_context.value()));
     }
 
     // Now append everything between the "tel:" prefix and the phone-context.
@@ -2228,9 +2228,9 @@ PhoneNumberUtil::ErrorType PhoneNumberUtil::BuildNationalNumberForParsing(
         static_cast<int>(index_of_rfc_prefix + strlen(kRfc3966Prefix)) : 0;
     StrAppend(
         national_number,
-        number_to_parse.substr(
+        StringHolder(number_to_parse.substr(
             index_of_national_number,
-            index_of_phone_context - index_of_national_number));
+            index_of_phone_context - index_of_national_number)));
   } else {
     // Extract a possible number from the string passed in (this strips leading
     // characters that could not be the start of a phone number.)


### PR DESCRIPTION
On Mac OS the build is failing since commit : https://github.com/google/libphonenumber/commit/e85a2ff1a75b46c09e3b889583ed1d38e9aa9f97 

The failure is:

```cpp
libphonenumber/cpp/src/phonenumbers/phonenumberutil.cc:2218:7: error: call to 'StrAppend' is ambiguous
      StrAppend(national_number, phone_context.value());
      ^~~~~~~~~
libphonenumber/cpp/build/_deps/abseil-cpp-src/absl/strings/str_cat.h:384:6: note: candidate function
void StrAppend(std::string* dest, const AlphaNum& a);
     ^
libphonenumber/cpp/src/phonenumbers/stringutil.h:186:6: note: candidate function
void StrAppend(string* dest, const StringHolder& s1);
     ^
libphonenumber/cpp/src/phonenumbers/phonenumberutil.cc:2229:5: error: call to 'StrAppend' is ambiguous
    StrAppend(
    ^~~~~~~~~
libphonenumber/cpp/build/_deps/abseil-cpp-src/absl/strings/str_cat.h:384:6: note: candidate function
void StrAppend(std::string* dest, const AlphaNum& a);
     ^
libphonenumber/cpp/src/phonenumbers/stringutil.h:186:6: note: candidate function
void StrAppend(string* dest, const StringHolder& s1);

```