### PR TITLE
Strip extension before appending formatted extension.

### DIFF
--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -1710,6 +1710,17 @@ void PhoneNumberUtil::FormatOutOfCountryKeepingAlphaChars(
     PrefixNumberWithCountryCallingCode(country_code, INTERNATIONAL,
                                        formatted_number);
   }
+  std::string region_code;
+  GetRegionCodeForCountryCode(country_code, &region_code);
+  // Metadata cannot be null because the country code is valid.
+  const PhoneMetadata* metadata_for_region =
+      GetMetadataForRegionOrCallingCode(country_code, region_code);
+  // Strip any extension
+  std::string extension;
+  MaybeStripExtension(formatted_number, &extension);
+  // Append the formatted extension
+  MaybeAppendFormattedExtension(number, *metadata_for_region, INTERNATIONAL,
+                                formatted_number);
 }
 
 const NumberFormat* PhoneNumberUtil::ChooseFormattingPatternForNumber(

--- a/cpp/test/phonenumbers/phonenumberutil_test.cc
+++ b/cpp/test/phonenumbers/phonenumberutil_test.cc
@@ -935,6 +935,16 @@ TEST_F(PhoneNumberUtilTest, FormatOutOfCountryKeepingAlphaChars) {
                                                   &formatted_number);
   EXPECT_EQ("1 800 SIX-FLAG", formatted_number);
 
+  // Testing a number with extension.
+  formatted_number.clear();
+  PhoneNumber alpha_numeric_number_with_extn;
+  phone_util_.ParseAndKeepRawInput("800 SIX-flag ext. 1234", RegionCode::US(),
+                                   &alpha_numeric_number_with_extn);
+  // preferredExtnPrefix for US is " extn. " (in test metadata)
+  phone_util_.FormatOutOfCountryKeepingAlphaChars(
+      alpha_numeric_number_with_extn, RegionCode::AU(), &formatted_number);
+  EXPECT_EQ("0011 1 800 SIX-FLAG extn. 1234", formatted_number);
+
   // Testing that if the raw input doesn't exist, it is formatted using
   // FormatOutOfCountryCallingNumber.
   alpha_numeric_number.clear_raw_input();

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -1878,8 +1878,11 @@ public class PhoneNumberUtil {
     String regionCode = getRegionCodeForCountryCode(countryCode);
     // Metadata cannot be null because the country calling code is valid.
     PhoneMetadata metadataForRegion = getMetadataForRegionOrCallingCode(countryCode, regionCode);
-    maybeAppendFormattedExtension(number, metadataForRegion,
-                                  PhoneNumberFormat.INTERNATIONAL, formattedNumber);
+    // Strip any extension
+    maybeStripExtension(formattedNumber);
+    // Append the formatted extension
+    maybeAppendFormattedExtension(
+        number, metadataForRegion, PhoneNumberFormat.INTERNATIONAL, formattedNumber);
     if (internationalPrefixForFormatting.length() > 0) {
       formattedNumber.insert(0, " ").insert(0, countryCode).insert(0, " ")
           .insert(0, internationalPrefixForFormatting);

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
@@ -675,7 +675,7 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
                  phoneUtil.formatOutOfCountryCallingNumber(IT_NUMBER, RegionCode.UZ));
   }
 
-  public void testFormatOutOfCountryKeepingAlphaChars() {
+  public void testFormatOutOfCountryKeepingAlphaChars() throws Exception {
     PhoneNumber alphaNumericNumber = new PhoneNumber();
     alphaNumericNumber.setCountryCode(1).setNationalNumber(8007493524L)
         .setRawInput("1800 six-flag");
@@ -700,6 +700,13 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
 
     assertEquals("1 800 SIX-FLAG",
                  phoneUtil.formatOutOfCountryKeepingAlphaChars(alphaNumericNumber, RegionCode.BS));
+
+    // Testing a number with extension.
+    PhoneNumber alphaNumericNumberWithExtn =
+        phoneUtil.parseAndKeepRawInput("800 SIX-flag ext. 1234", RegionCode.US);
+    assertEquals(
+        "0011 1 800 SIX-FLAG extn. 1234",
+        phoneUtil.formatOutOfCountryKeepingAlphaChars(alphaNumericNumberWithExtn, RegionCode.AU));
 
     // Testing that if the raw input doesn't exist, it is formatted using
     // formatOutOfCountryCallingNumber.

--- a/pending_code_changes.txt
+++ b/pending_code_changes.txt
@@ -1,1 +1,2 @@
-
+Code changes:
+ - Fixed a bug where the extension was appended twice in formatOutOfCountryKeepingAlphaChars in the Java version and updated FormatOutOfCountryKeepingAlphaChars in the C++ version to format the extension.


### PR DESCRIPTION
This is to ensure that the extension is not included twice in the formatted number.

Unlike the Java version, the C++ version didn't format extensions at all which is fixed in this change.

Context: b/309836518