### PR TITLE
Add missing range for Georgian operator - Magticom

### DIFF
--- a/resources/metadata/995/ranges.csv
+++ b/resources/metadata/995/ranges.csv
@@ -109,6 +109,7 @@ Prefix          ; Length ; Type       ; Tariff        ; Area Code Length ; Natio
 5115[2-6]       ; 9      ; MOBILE     ; STANDARD_RATE ;                  ; false         ; "magticom"         ; "mobile_3/2/2/2" ; "GE"    ;                         ; IR21
 5117[0-4]       ; 9      ; MOBILE     ; STANDARD_RATE ;                  ; false         ; "magticom"         ; "mobile_3/2/2/2" ; "GE"    ;                         ; IR21
 51177[5-9]      ; 9      ; MOBILE     ; STANDARD_RATE ;                  ; false         ; "magticom"         ; "mobile_3/2/2/2" ; "GE"    ;                         ; IR21
+511             ; 9      ; MOBILE     ; STANDARD_RATE ;                  ; false         ; "magticom"         ; "mobile_3/2/2/2" ; "GE"    ;                         ; IR21
 514             ; 9      ; MOBILE     ; STANDARD_RATE ;                  ; false         ; "silknet"          ; "mobile_3/2/2/2" ; "GE"    ;                         ; IR21
 51555[5-9]      ; 9      ; MOBILE     ; STANDARD_RATE ;                  ; false         ; "magticom"         ; "mobile_3/2/2/2" ; "GE"    ;                         ; IR21
 51777[5-9]      ; 9      ; MOBILE     ; STANDARD_RATE ;                  ; false         ; "magticom"         ; "mobile_3/2/2/2" ; "GE"    ;                         ; IR21


### PR DESCRIPTION
*   Country: Georgia
*   Example number(s) and/or range(s): 511123123
*   Number type ("fixed-line", "mobile", "short code", etc.): mobile
*   For short codes, cost and dialing restrictions: NO
*   Where or whom did you get the number(s) from: -
*   Authoritative evidence (e.g. national numbering plan, operator announcement): -
*   Link from demo (http://libphonenumber.appspot.com) showing error: -

This PR adds support for phone numbers starting with 511. Magticom has this index 10 or 15 years already, it's not new.

You can check that this index is valid [here](https://www.magticom.ge/en/mymagti/online-order/number-activation) (Official website, click on ALL to see 511 in dopdown list) and [here](https://en.wikipedia.org/wiki/Telephone_numbers_in_Georgia_(country)#:~:text=511,MagtiCom)