### PR TITLE
Removed Automatic-Module-Name from carrier and geocoder...

### DIFF
--- a/java/carrier/pom.xml
+++ b/java/carrier/pom.xml
@@ -52,10 +52,6 @@
                 <manifestFile>
                   ${project.build.outputDirectory}/META-INF/MANIFEST.MF
                 </manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>com.google.i18n.phonenumbers.carrier
-                  </Automatic-Module-Name>
-                </manifestEntries>
               </archive>
             </configuration>
           </execution>

--- a/java/geocoder/pom.xml
+++ b/java/geocoder/pom.xml
@@ -62,10 +62,6 @@
                 <manifestFile>
                   ${project.build.outputDirectory}/META-INF/MANIFEST.MF
                 </manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>com.google.i18n.phonenumbers.geocoder
-                  </Automatic-Module-Name>
-                </manifestEntries>
               </archive>
             </configuration>
           </execution>


### PR DESCRIPTION
...Classes in these modules belong to the same package as core libphonenumber library, which leads to the split package problem with Java modules.