### PR TITLE
Add Dev Container and gitignore

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/devcontainers/base:debian
+
+RUN apt update
+RUN apt install -y wget curl ant maven protobuf-compiler
+
+# Install JDK 8
+RUN wget https://javadl.oracle.com/webapps/download/GetFile/1.8.0_321-b07/df5ad55fdd604472a86a45a217032c7d/linux-i586/jdk-8u321-linux-x64.tar.gz \
+&& tar xvzf jdk-8u321-linux-x64.tar.gz \
+&& ls \
+&& mv jdk1.8.0_321/ /usr/lib/jvm \
+&& ls /usr/lib/jvm \
+&& update-alternatives --install /usr/bin/java java /usr/lib/jvm/jdk1.8.0_321/bin/java 9999 \
+&& sudo update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/jdk1.8.0_321/bin/javac 9999 \
+&& sudo update-alternatives --install /usr/bin/jar jar /usr/lib/jvm/jdk1.8.0_321/bin/jar 9999
+
+# Install C++ developer env
+RUN dpkg --configure -a \
+&& apt install -y cmake cmake-curses-gui libprotobuf-dev libgtest-dev libre2-dev \
+libicu-dev libboost-dev libboost-thread-dev libboost-system-dev
+
+# Install Appengine for demo
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+&& curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+&& apt update -y && apt install google-cloud-cli -y
+RUN apt install -y python3
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
+{
+	"name": "libphonenumber-dev",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "image": "mcr.microsoft.com/devcontainers/base:alpine-3.20"
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"vscjava.vscode-java-pack",
+				"eamodio.gitlens",
+				"ms-vscode.cpptools-extension-pack"
+			]
+		}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ target/
 build/
 lib/
 generated/
+.gradle
+cpp/test/phonenumbers/geocoding/geocoding_test_data.cc
+cpp/src/phonenumbers/geocoding/geocoding_data.cc
+cpp/**/*.pb.cc
+cpp/**/*.pb.h

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "cmake.sourceDirectory": "${workspaceFolder}/cpp",
+    "cmake.buildDirectory": "${workspaceFolder}/cpp/build"
+}


### PR DESCRIPTION
This adds config for a devcontainer to make it easier to get started developing.
Some untracked files that are generated during build are also added to the gitignore.