### PR TITLE
Add "()" when string.match() is executed in js

### DIFF
--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -4760,7 +4760,7 @@ i18n.phonenumbers.PhoneNumberUtil.prototype.canBeInternationallyDialled =
 i18n.phonenumbers.PhoneNumberUtil.matchesEntirely = function(regex, str) {
   /** @type {Array.<string>} */
   var matchedGroups = (typeof regex == 'string') ?
-      str.match('^(?:' + regex + ')$') : str.match(regex);
+      str.match('^(?:' + regex + ')$') : str.match("^(?:" + regex.source + ")$");
   if (matchedGroups && matchedGroups[0].length == str.length) {
     return true;
   }

--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -4759,7 +4759,7 @@ i18n.phonenumbers.PhoneNumberUtil.prototype.canBeInternationallyDialled =
  */
 i18n.phonenumbers.PhoneNumberUtil.matchesEntirely = function(regex, str) {
   /** @type {Array.<string>} */
-  var matchedGroups = str.match('^(?:' + (typeof regex == 'string' ? regex : regex.source) + ')$')
+  var matchedGroups = str.match(new RegExp('^(?:' + (typeof regex == 'string' ? regex : regex.source) + ')$', 'i'));
   if (matchedGroups && matchedGroups[0].length == str.length) {
     return true;
   }

--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -4759,8 +4759,7 @@ i18n.phonenumbers.PhoneNumberUtil.prototype.canBeInternationallyDialled =
  */
 i18n.phonenumbers.PhoneNumberUtil.matchesEntirely = function(regex, str) {
   /** @type {Array.<string>} */
-  var matchedGroups = (typeof regex == 'string') ?
-      str.match('^(?:' + regex + ')$') : str.match("^(?:" + regex.source + ")$");
+  var matchedGroups = b2.match('^(?:' + (typeof a2 == 'string' ? a2 : a2.source) + ')$')
   if (matchedGroups && matchedGroups[0].length == str.length) {
     return true;
   }

--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -4759,7 +4759,7 @@ i18n.phonenumbers.PhoneNumberUtil.prototype.canBeInternationallyDialled =
  */
 i18n.phonenumbers.PhoneNumberUtil.matchesEntirely = function(regex, str) {
   /** @type {Array.<string>} */
-  var matchedGroups = b2.match('^(?:' + (typeof a2 == 'string' ? a2 : a2.source) + ')$')
+  var matchedGroups = str.match('^(?:' + (typeof regex == 'string' ? regex : regex.source) + ')$')
   if (matchedGroups && matchedGroups[0].length == str.length) {
     return true;
   }


### PR DESCRIPTION
Without "()", when many conditions exist and former one is matched, it returns the wrong value. So adding "()" for the regex

I think it doesn't happen in Java and cpp

[related issue] (raised by myself)
https://issuetracker.google.com/issues/383824582

[java]
https://github.com/google/libphonenumber/blob/master/java/libphonenumber/src/com/google/i18n/phonenumbers/internal/RegexBasedMatcher.java#L49-L56

[cpp]
https://github.com/google/libphonenumber/blob/master/cpp/src/phonenumbers/regex_based_matcher.cc#L51-L65