### PR TITLE
Libphonenumber JS API is not able to parse numbers with missing '+' u…

### DIFF
--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -3852,7 +3852,7 @@ i18n.phonenumbers.PhoneNumberUtil.prototype.maybeExtractCountryCode =
       var generalDesc = defaultRegionMetadata.getGeneralDesc();
       /** @type {!RegExp} */
       var validNumberPattern =
-          new RegExp(generalDesc.getNationalNumberPatternOrDefault());
+          new RegExp('^(?:' + generalDesc.getNationalNumberPatternOrDefault() + ')$');
       // Passing null since we don't need the carrier code.
       this.maybeStripNationalPrefixAndCarrierCode(
           potentialNationalNumber, defaultRegionMetadata, null);

--- a/javascript/i18n/phonenumbers/phonenumberutil_test.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil_test.js
@@ -2758,6 +2758,24 @@ function testMaybeExtractCountryCode() {
   } catch (e) {
     fail('Should not have thrown an exception: ' + e.toString());
   }
+  number = new i18n.phonenumbers.PhoneNumber();
+  try {
+    phoneNumber = '821064588888';
+    metadata  = phoneUtil.getMetadataForRegion(RegionCode.KR);
+    countryCallingCode = 82;
+    numberToFill = new goog.string.StringBuffer();
+    assertEquals(
+        'Should have extracted the country calling code of the ' +
+            'region passed in',
+        countryCallingCode,
+        phoneUtil.maybeExtractCountryCode(
+            phoneNumber, metadata, numberToFill, true, number));
+    assertEquals(
+        'Did figure out CountryCodeSource correctly',
+        CCS.FROM_NUMBER_WITHOUT_PLUS_SIGN, number.getCountryCodeSource());
+  } catch (e) {
+    fail('Should not have thrown an exception: ' + e.toString());
+  }
 }
 
 function testParseNationalNumber() {


### PR DESCRIPTION
Libphonenumber JS API is not able to parse numbers with missing '+' unlike Java.

Here the issue is while matching numbers with regex pattern, some of the numbers length is not giving properly.

Without adding "('^(?:' + generalDesc.getNationalNumberPatternOrDefault() + ')$')" it will be matched with a partial string. due to that matched string length is coming differently so that condition is failing. To match the entire string needs to add this condition->"('^(?:' + '' + ')$')".