### PR TITLE
Refactor phone context parsing for RFC3966 numbers.

### DIFF
--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java
@@ -573,7 +573,7 @@ public class AsYouTypeFormatter {
    */
   private boolean attemptToExtractIdd() {
     Pattern internationalPrefix =
-        regexCache.getPatternForRegex("\\" + PhoneNumberUtil.PLUS_SIGN + "|"
+        regexCache.getPatternForRegex("\\" + Constants.PLUS_SIGN + "|"
             + currentMetadata.getInternationalPrefix());
     Matcher iddMatcher = internationalPrefix.matcher(accruedInputWithoutFormatting);
     if (iddMatcher.lookingAt()) {
@@ -584,7 +584,7 @@ public class AsYouTypeFormatter {
       prefixBeforeNationalNumber.setLength(0);
       prefixBeforeNationalNumber.append(
           accruedInputWithoutFormatting.substring(0, startOfCountryCallingCode));
-      if (accruedInputWithoutFormatting.charAt(0) != PhoneNumberUtil.PLUS_SIGN) {
+      if (accruedInputWithoutFormatting.charAt(0) != Constants.PLUS_SIGN) {
         prefixBeforeNationalNumber.append(SEPARATOR_BEFORE_NATIONAL_NUMBER);
       }
       return true;
@@ -631,7 +631,7 @@ public class AsYouTypeFormatter {
   // digit or the plus sign.
   private char normalizeAndAccrueDigitsAndPlusSign(char nextChar, boolean rememberPosition) {
     char normalizedChar;
-    if (nextChar == PhoneNumberUtil.PLUS_SIGN) {
+    if (nextChar == Constants.PLUS_SIGN) {
       normalizedChar = nextChar;
       accruedInputWithoutFormatting.append(nextChar);
     } else {

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/Constants.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/Constants.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2025 The Libphonenumber Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.i18n.phonenumbers;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/** Constants used by the PhoneNumberUtil. */
+final class Constants {
+  // The maximum length of the country calling code.
+  static final int MAX_LENGTH_COUNTRY_CODE = 3;
+
+  // Map of country calling codes that use a mobile token before the area code. One example of when
+  // this is relevant is when determining the length of the national destination code, which should
+  // be the length of the area code plus the length of the mobile token.
+  static final Map<Integer, String> MOBILE_TOKEN_MAPPINGS;
+
+  // Set of country codes that have geographically assigned mobile numbers (see GEO_MOBILE_COUNTRIES
+  // below) which are not based on *area codes*. For example, in China mobile numbers start with a
+  // carrier indicator, and beyond that are geographically assigned: this carrier indicator is not
+  // considered to be an area code.
+  static final Set<Integer> GEO_MOBILE_COUNTRIES_WITHOUT_MOBILE_AREA_CODES;
+
+  // Set of country codes that doesn't have national prefix, but it has area codes.
+  static final Set<Integer> COUNTRIES_WITHOUT_NATIONAL_PREFIX_WITH_AREA_CODES;
+
+  // Set of country calling codes that have geographically assigned mobile numbers. This may not be
+  // complete; we add calling codes case by case, as we find geographical mobile numbers or hear
+  // from user reports. Note that countries like the US, where we can't distinguish between
+  // fixed-line or mobile numbers, are not listed here, since we consider FIXED_LINE_OR_MOBILE to be
+  // a possibly geographically-related type anyway (like FIXED_LINE).
+  static final Set<Integer> GEO_MOBILE_COUNTRIES;
+
+  // The PLUS_SIGN signifies the international prefix.
+  static final char PLUS_SIGN = '+';
+
+  static final String RFC3966_PHONE_CONTEXT = ";phone-context=";
+
+  // A map that contains characters that are essential when dialling. That means any of the
+  // characters in this map must not be removed from a number when dialling, otherwise the call
+  // will not reach the intended destination.
+  static final Map<Character, Character> DIALLABLE_CHAR_MAPPINGS;
+
+
+  // Only upper-case variants of alpha characters are stored.
+  static final Map<Character, Character> ALPHA_MAPPINGS;
+
+  // For performance reasons, amalgamate both into one map.
+  static final Map<Character, Character> ALPHA_PHONE_MAPPINGS;
+
+  // Separate map of all symbols that we wish to retain when formatting alpha numbers. This
+  // includes digits, ASCII letters and number grouping symbols such as "-" and " ".
+  static final Map<Character, Character> ALL_PLUS_NUMBER_GROUPING_SYMBOLS;
+
+  static {
+    HashMap<Integer, String> mobileTokenMap = new HashMap<>();
+    mobileTokenMap.put(54, "9");
+    MOBILE_TOKEN_MAPPINGS = Collections.unmodifiableMap(mobileTokenMap);
+
+    HashSet<Integer> geoMobileCountriesWithoutMobileAreaCodes = new HashSet<>();
+    geoMobileCountriesWithoutMobileAreaCodes.add(86); // China
+    GEO_MOBILE_COUNTRIES_WITHOUT_MOBILE_AREA_CODES =
+        Collections.unmodifiableSet(geoMobileCountriesWithoutMobileAreaCodes);
+
+    HashSet<Integer> countriesWithoutNationalPrefixWithAreaCodes = new HashSet<>();
+    countriesWithoutNationalPrefixWithAreaCodes.add(52); // Mexico
+    COUNTRIES_WITHOUT_NATIONAL_PREFIX_WITH_AREA_CODES =
+        Collections.unmodifiableSet(countriesWithoutNationalPrefixWithAreaCodes);
+
+    HashSet<Integer> geoMobileCountries = new HashSet<>();
+    geoMobileCountries.add(52); // Mexico
+    geoMobileCountries.add(54); // Argentina
+    geoMobileCountries.add(55); // Brazil
+    geoMobileCountries.add(62); // Indonesia: some prefixes only (fixed CMDA wireless)
+    geoMobileCountries.addAll(geoMobileCountriesWithoutMobileAreaCodes);
+    GEO_MOBILE_COUNTRIES = Collections.unmodifiableSet(geoMobileCountries);
+
+    // Simple ASCII digits map used to populate ALPHA_PHONE_MAPPINGS and
+    // ALL_PLUS_NUMBER_GROUPING_SYMBOLS.
+    HashMap<Character, Character> asciiDigitMappings = new HashMap<>();
+    asciiDigitMappings.put('0', '0');
+    asciiDigitMappings.put('1', '1');
+    asciiDigitMappings.put('2', '2');
+    asciiDigitMappings.put('3', '3');
+    asciiDigitMappings.put('4', '4');
+    asciiDigitMappings.put('5', '5');
+    asciiDigitMappings.put('6', '6');
+    asciiDigitMappings.put('7', '7');
+    asciiDigitMappings.put('8', '8');
+    asciiDigitMappings.put('9', '9');
+
+    HashMap<Character, Character> alphaMap = new HashMap<>(40);
+    alphaMap.put('A', '2');
+    alphaMap.put('B', '2');
+    alphaMap.put('C', '2');
+    alphaMap.put('D', '3');
+    alphaMap.put('E', '3');
+    alphaMap.put('F', '3');
+    alphaMap.put('G', '4');
+    alphaMap.put('H', '4');
+    alphaMap.put('I', '4');
+    alphaMap.put('J', '5');
+    alphaMap.put('K', '5');
+    alphaMap.put('L', '5');
+    alphaMap.put('M', '6');
+    alphaMap.put('N', '6');
+    alphaMap.put('O', '6');
+    alphaMap.put('P', '7');
+    alphaMap.put('Q', '7');
+    alphaMap.put('R', '7');
+    alphaMap.put('S', '7');
+    alphaMap.put('T', '8');
+    alphaMap.put('U', '8');
+    alphaMap.put('V', '8');
+    alphaMap.put('W', '9');
+    alphaMap.put('X', '9');
+    alphaMap.put('Y', '9');
+    alphaMap.put('Z', '9');
+    ALPHA_MAPPINGS = Collections.unmodifiableMap(alphaMap);
+
+    HashMap<Character, Character> combinedMap = new HashMap<>(100);
+    combinedMap.putAll(ALPHA_MAPPINGS);
+    combinedMap.putAll(asciiDigitMappings);
+    ALPHA_PHONE_MAPPINGS = Collections.unmodifiableMap(combinedMap);
+
+    HashMap<Character, Character> diallableCharMap = new HashMap<>();
+    diallableCharMap.putAll(asciiDigitMappings);
+    diallableCharMap.put(PLUS_SIGN, PLUS_SIGN);
+    diallableCharMap.put('*', '*');
+    diallableCharMap.put('#', '#');
+    DIALLABLE_CHAR_MAPPINGS = Collections.unmodifiableMap(diallableCharMap);
+
+    HashMap<Character, Character> allPlusNumberGroupings = new HashMap<>();
+    // Put (lower letter -> upper letter) and (upper letter -> upper letter) mappings.
+    for (char c : ALPHA_MAPPINGS.keySet()) {
+      allPlusNumberGroupings.put(Character.toLowerCase(c), c);
+      allPlusNumberGroupings.put(c, c);
+    }
+    allPlusNumberGroupings.putAll(asciiDigitMappings);
+    // Put grouping symbols.
+    allPlusNumberGroupings.put('-', '-');
+    allPlusNumberGroupings.put('\uFF0D', '-');
+    allPlusNumberGroupings.put('\u2010', '-');
+    allPlusNumberGroupings.put('\u2011', '-');
+    allPlusNumberGroupings.put('\u2012', '-');
+    allPlusNumberGroupings.put('\u2013', '-');
+    allPlusNumberGroupings.put('\u2014', '-');
+    allPlusNumberGroupings.put('\u2015', '-');
+    allPlusNumberGroupings.put('\u2212', '-');
+    allPlusNumberGroupings.put('/', '/');
+    allPlusNumberGroupings.put('\uFF0F', '/');
+    allPlusNumberGroupings.put(' ', ' ');
+    allPlusNumberGroupings.put('\u3000', ' ');
+    allPlusNumberGroupings.put('\u2060', ' ');
+    allPlusNumberGroupings.put('.', '.');
+    allPlusNumberGroupings.put('\uFF0E', '.');
+    ALL_PLUS_NUMBER_GROUPING_SYMBOLS = Collections.unmodifiableMap(allPlusNumberGroupings);
+  }
+
+  static final String DIGITS = "\\p{Nd}";
+  // We accept alpha characters in phone numbers, ASCII only, upper and lower case.
+  static final String VALID_ALPHA =
+      Arrays.toString(ALPHA_MAPPINGS.keySet().toArray()).replaceAll("[, \\[\\]]", "")
+          + Arrays.toString(ALPHA_MAPPINGS.keySet().toArray())
+              .toLowerCase().replaceAll("[, \\[\\]]", "");
+
+  // We use this pattern to check if the phone number has at least three letters in it - if so, then
+  // we treat it as a number where some phone-number digits are represented by letters.
+  static final Pattern VALID_ALPHA_PHONE_PATTERN = Pattern.compile("(?:.*?[A-Za-z]){3}.*");
+
+  // Regular expression of valid global-number-digits for the phone-context parameter, following the
+  // syntax defined in RFC3966.
+  static final String RFC3966_VISUAL_SEPARATOR = "[\\-\\.\\(\\)]?";
+  static final String RFC3966_PHONE_DIGIT =
+      "(" + DIGITS + "|" + RFC3966_VISUAL_SEPARATOR + ")";
+  static final String RFC3966_GLOBAL_NUMBER_DIGITS =
+      "^\\" + PLUS_SIGN + RFC3966_PHONE_DIGIT + "*" + DIGITS + RFC3966_PHONE_DIGIT + "*$";
+  static final Pattern RFC3966_GLOBAL_NUMBER_DIGITS_PATTERN =
+      Pattern.compile(RFC3966_GLOBAL_NUMBER_DIGITS);
+
+  // Regular expression of valid domainname for the phone-context parameter, following the syntax
+  // defined in RFC3966.
+  static final String ALPHANUM = VALID_ALPHA + DIGITS;
+  static final String RFC3966_DOMAINLABEL =
+      "[" + ALPHANUM + "]+((\\-)*[" + ALPHANUM + "])*";
+  static final String RFC3966_TOPLABEL =
+      "[" + VALID_ALPHA + "]+((\\-)*[" + ALPHANUM + "])*";
+  static final String RFC3966_DOMAINNAME =
+      "^(" + RFC3966_DOMAINLABEL + "\\.)*" + RFC3966_TOPLABEL + "\\.?$";
+  static final Pattern RFC3966_DOMAINNAME_PATTERN = Pattern.compile(RFC3966_DOMAINNAME);
+
+  private Constants() {}
+}

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneContextParser.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneContextParser.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2025 The Libphonenumber Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.i18n.phonenumbers;
+
+import java.util.Set;
+
+/** Utility class for parsing the phone-context parameter of a phone number. */
+final class PhoneContextParser {
+  private final Set<Integer> countryCallingCodeSet;
+
+  PhoneContextParser(Set<Integer> countryCallingCodeSet) {
+    this.countryCallingCodeSet = countryCallingCodeSet;
+  }
+
+  /**
+   * Extracts the value of the phone-context parameter of numberToExtractFrom, following the
+   * syntax defined in RFC3966.
+   *
+   * @return the extracted string (possibly empty), or null if no phone-context parameter is
+   *         found.
+   */
+  private static String extractPhoneContext(String number) {
+    int indexOfPhoneContext = number.indexOf(Constants.RFC3966_PHONE_CONTEXT);
+
+    // If no phone-context parameter is present
+    if (indexOfPhoneContext == -1) {
+      return null;
+    }
+
+    int phoneContextStart = indexOfPhoneContext + Constants.RFC3966_PHONE_CONTEXT.length();
+    // If phone-context parameter is empty
+    if (phoneContextStart >= number.length()) {
+      return "";
+    }
+
+    int phoneContextEnd = number.indexOf(';', phoneContextStart);
+    // If phone-context is the last parameter
+    if (phoneContextEnd < 0) {
+      return number.substring(phoneContextStart);
+    } else {
+      return number.substring(phoneContextStart, phoneContextEnd);
+    }
+  }
+
+  /**
+   * Returns whether the value of phoneContext follows the syntax defined in RFC3966.
+   */
+  private static boolean isValid(String phoneContext) {
+    if (phoneContext.equals("")) {
+      return false;
+    }
+
+    // Does phone-context value match pattern of global-number-digits or domain name
+    return Constants.RFC3966_GLOBAL_NUMBER_DIGITS_PATTERN.matcher(phoneContext).matches()
+        || Constants.RFC3966_DOMAINNAME_PATTERN.matcher(phoneContext).matches();
+  }
+
+  /** Checks if the int is a valid country calling code. */
+  private boolean isValidCountryCode(int countryCode) {
+    return countryCallingCodeSet.contains(countryCode);
+  }
+
+  /**
+   * Parses the value of the phone-context parameter of number, following the syntax defined in
+   * RFC3966.
+   *
+   * @return the parsed phone-context parameter as a PhoneContext object, or null if no
+   *         phone-context parameter is found.
+   */
+  private PhoneContext parsePhoneContext(String phoneContext) {
+    // Ignore phone-context values that do not start with a plus sign. Could be a domain name.
+    if (phoneContext.charAt(0) != Constants.PLUS_SIGN) {
+      return new PhoneContext().setRawContext(phoneContext).setCountryCode(null);
+    }
+
+    // Remove the plus sign from the phone context and normalize the digits.
+    String normalizedPhoneContext =
+        PhoneNumberNormalizer.normalizeDigitsOnly(phoneContext.substring(1));
+
+    // Check if the phone context is a valid country calling code.
+    if (!normalizedPhoneContext.equals("")
+        && normalizedPhoneContext.length() <= Constants.MAX_LENGTH_COUNTRY_CODE) {
+      int potentialCountryCode = Integer.parseInt(normalizedPhoneContext);
+      if (isValidCountryCode(potentialCountryCode)) {
+        return new PhoneContext().setRawContext(phoneContext).setCountryCode(potentialCountryCode);
+      }
+    }
+
+    // If the country code is not valid, return the phone context as is.
+    return new PhoneContext().setRawContext(phoneContext).setCountryCode(null);
+  }
+
+  /**
+   * Parses the phone-context parameter of number, following the syntax defined in RFC3966.
+   *
+   * @return the parsed phone-context parameter as a PhoneContext object, or null if no
+   *         phone-context parameter is found.
+   * @throws NumberParseException if the phone-context parameter is invalid.
+   */
+  PhoneContext parse(String number) throws NumberParseException {
+    String phoneContext = extractPhoneContext(number);
+
+    if (phoneContext == null) {
+      return null;
+    }
+
+    if (!isValid(phoneContext)) {
+      throw new NumberParseException(NumberParseException.ErrorType.NOT_A_NUMBER,
+          "The phone-context value is invalid.");
+    }
+
+    return parsePhoneContext(phoneContext);
+  }
+
+  /** Represents the parsed phone-context parameter of an RFC3966 tel-URI. */
+  static class PhoneContext {
+    /** The raw value of the phone-context parameter. */
+    private String rawContext_ = null;
+
+    /**
+     * The country code of the phone-context parameter if the phone-context parameter is exactly
+     * and only a + followed by a valid country code.
+     *
+     * <p>
+     * For example, if the phone-context parameter is "+1", the country code is 1. If the
+     * phone-context parameter is "+123", the country code is null.
+     */
+    private Integer countryCode_ = null;
+
+    /** Get the value for {@link #rawContext_} */
+    String getRawContext() {
+      return rawContext_;
+    }
+
+    /** Set the value for {@link #rawContext_} */
+    PhoneContext setRawContext(String value) {
+      rawContext_ = value;
+      return this;
+    }
+
+    /** Get the value for {@link #countryCode_} */
+    Integer getCountryCode() {
+      return countryCode_;
+    }
+
+    /** Set the value for {@link #countryCode_} */
+    PhoneContext setCountryCode(Integer value) {
+      countryCode_ = value;
+      return this;
+    }
+  }
+}

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatcher.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatcher.java
@@ -151,8 +151,7 @@ final class PhoneNumberMatcher implements Iterator<PhoneNumberMatch> {
     /* The maximum number of digits allowed in a digit-separated block. As we allow all digits in a
      * single block, set high enough to accommodate the entire national number and the international
      * country code. */
-    int digitBlockLimit =
-        PhoneNumberUtil.MAX_LENGTH_FOR_NSN + PhoneNumberUtil.MAX_LENGTH_COUNTRY_CODE;
+    int digitBlockLimit = PhoneNumberUtil.MAX_LENGTH_FOR_NSN + Constants.MAX_LENGTH_COUNTRY_CODE;
     /* Limit on the number of blocks separated by punctuation. Uses digitBlockLimit since some
      * formats use spaces to separate each digit. */
     String blockLimit = limit(0, digitBlockLimit);
@@ -569,7 +568,7 @@ final class PhoneNumberMatcher implements Iterator<PhoneNumberMatch> {
       PhoneNumber number, CharSequence candidate, PhoneNumberUtil util,
       NumberGroupingChecker checker) {
     StringBuilder normalizedCandidate =
-        PhoneNumberUtil.normalizeDigits(candidate, true /* keep non-digits */);
+        PhoneNumberNormalizer.normalizeDigits(candidate, true /* keep non-digits */);
     String[] formattedNumberGroups = getNationalNumberGroups(util, number);
     if (checker.checkGroups(util, number, normalizedCandidate, formattedNumberGroups)) {
       return true;
@@ -618,7 +617,7 @@ final class PhoneNumberMatcher implements Iterator<PhoneNumberMatch> {
         (number.getCountryCodeSource() == CountryCodeSource.FROM_NUMBER_WITH_PLUS_SIGN
          || number.getCountryCodeSource() == CountryCodeSource.FROM_NUMBER_WITHOUT_PLUS_SIGN);
     if (candidateHasCountryCode
-        && PhoneNumberUtil.normalizeDigitsOnly(candidate.substring(0, firstSlashInBodyIndex))
+        && PhoneNumberNormalizer.normalizeDigitsOnly(candidate.substring(0, firstSlashInBodyIndex))
             .equals(Integer.toString(number.getCountryCode()))) {
       // Any more slashes and this is illegal.
       return candidate.substring(secondSlashInBodyIndex + 1).contains("/");
@@ -646,7 +645,7 @@ final class PhoneNumberMatcher implements Iterator<PhoneNumberMatch> {
           }
         // This is the extension sign case, in which the 'x' or 'X' should always precede the
         // extension number.
-        } else if (!PhoneNumberUtil.normalizeDigitsOnly(candidate.substring(index)).equals(
+        } else if (!PhoneNumberNormalizer.normalizeDigitsOnly(candidate.substring(index)).equals(
             number.getExtension())) {
           return false;
         }
@@ -685,7 +684,7 @@ final class PhoneNumberMatcher implements Iterator<PhoneNumberMatch> {
         return true;
       }
       // Normalize the remainder.
-      String rawInputCopy = PhoneNumberUtil.normalizeDigitsOnly(number.getRawInput());
+      String rawInputCopy = PhoneNumberNormalizer.normalizeDigitsOnly(number.getRawInput());
       StringBuilder rawInput = new StringBuilder(rawInputCopy);
       // Check if we found a national prefix and/or carrier code at the start of the raw input, and
       // return the result.

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberNormalizer.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberNormalizer.java
@@ -1,0 +1,40 @@
+package com.google.i18n.phonenumbers;
+
+/** Utility class for normalizing phone numbers. */
+final class PhoneNumberNormalizer {
+  private PhoneNumberNormalizer() {}
+
+  /**
+   * Normalizes a string of characters representing a phone number. This converts wide-ascii and
+   * arabic-indic numerals to European numerals, and strips punctuation and alpha characters.
+   *
+   * @param number a string of characters representing a phone number
+   * @return the normalized string version of the phone number
+   */
+  static String normalizeDigitsOnly(CharSequence number) {
+    return normalizeDigits(number, false /* strip non-digits */).toString();
+  }
+
+  /**
+   * Helper method for normalizing a string of characters representing a phone number. See {@link
+   * PhoneNumberUtil#normalize(StringBuilder)} and {@link #normalizeDigitsOnly(CharSequence)} for
+   * more details.
+   *
+   * @param number a string of characters representing a phone number
+   * @param keepNonDigits whether to keep non-digits in the normalized string
+   * @return the normalized string version of the phone number
+   */
+  static StringBuilder normalizeDigits(CharSequence number, boolean keepNonDigits) {
+    StringBuilder normalizedDigits = new StringBuilder(number.length());
+    for (int i = 0; i < number.length(); i++) {
+      char c = number.charAt(i);
+      int digit = Character.digit(c, 10);
+      if (digit != -1) {
+        normalizedDigits.append(digit);
+      } else if (keepNonDigits) {
+        normalizedDigits.append(c);
+      }
+    }
+    return normalizedDigits;
+  }
+}

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/ShortNumberInfo.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/ShortNumberInfo.java
@@ -458,7 +458,7 @@ public class ShortNumberInfo {
       return false;
     }
 
-    String normalizedNumber = PhoneNumberUtil.normalizeDigitsOnly(possibleNumber);
+    String normalizedNumber = PhoneNumberNormalizer.normalizeDigitsOnly(possibleNumber);
     boolean allowPrefixMatchForRegion =
         allowPrefixMatch && !REGIONS_WHERE_EMERGENCY_NUMBERS_MUST_BE_EXACT.contains(regionCode);
     return matcherApi.matchNationalNumber(normalizedNumber, metadata.getEmergency(),

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneContextParserTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneContextParserTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025 The Libphonenumber Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.i18n.phonenumbers;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.function.ThrowingRunnable;
+import com.google.i18n.phonenumbers.PhoneContextParser.PhoneContext;
+import junit.framework.TestCase;
+
+/**
+ * Unit tests for PhoneContextParser.java
+ */
+public class PhoneContextParserTest extends TestCase {
+
+  private static final Set<Integer> countryCallingCodeSet;
+  static {
+    Set<Integer> tempSet = new HashSet<>();
+    tempSet.add(64);
+    countryCallingCodeSet = Collections.unmodifiableSet(tempSet);
+  }
+
+  /**
+   * An instance of PhoneContextParser.
+   */
+  protected final PhoneContextParser phoneContextParser =
+      new PhoneContextParser(countryCallingCodeSet);
+
+  public void testParseShouldWorkAsExpected() throws NumberParseException {
+    PhoneContext actual;
+
+    actual = phoneContextParser.parse("tel:03-331-6005;phone-context=+64");
+    assertEquals("+64", actual.getRawContext());
+    assertEquals(new Integer(64), actual.getCountryCode());
+    
+    actual = phoneContextParser.parse("tel:03-331-6005;phone-context=example.com");
+    assertEquals("example.com", actual.getRawContext());
+    assertNull(actual.getCountryCode());
+    
+    actual = phoneContextParser.parse("03-331-6005;phone-context=+64;");
+    assertEquals("+64", actual.getRawContext());
+    assertEquals(new Integer(64), actual.getCountryCode());
+    
+    actual = phoneContextParser.parse("+64-3-331-6005;phone-context=+64;");
+    assertEquals("+64", actual.getRawContext());
+    assertEquals(new Integer(64), actual.getCountryCode());
+    
+    actual = phoneContextParser.parse("tel:03-331-6005;foo=bar;phone-context=+64;baz=qux");
+    assertEquals("+64", actual.getRawContext());
+    assertEquals(new Integer(64), actual.getCountryCode());
+    
+    actual = phoneContextParser.parse("tel:03-331-6005");
+    assertNull(actual);
+    
+    actual = phoneContextParser.parse("tel:03-331-6005;phone-context=+0");
+    assertEquals("+0", actual.getRawContext());
+    assertNull(actual.getCountryCode());
+    
+    actual = phoneContextParser.parse("tel:03-331-6005;phone-context=+1234");
+    assertEquals("+1234", actual.getRawContext());
+    assertNull(actual.getCountryCode());
+  }
+
+  public void testParseShouldFailForInvalidPhoneContext() throws NumberParseException {
+    assertThrows(
+        NumberParseException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws NumberParseException {
+            phoneContextParser.parse("tel:03-331-6005;phone-context=");
+          }
+        });
+    assertThrows(
+        NumberParseException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws NumberParseException {
+            phoneContextParser.parse("tel:03-331-6005;phone-context=;");
+          }
+        });
+    assertThrows(
+        NumberParseException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws NumberParseException {
+            phoneContextParser.parse("tel:03-331-6005;phone-context=0");
+          }
+        });
+  }
+
+}

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
@@ -481,7 +481,7 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
     String expectedOutput = "03456234";
     assertEquals("Conversion did not correctly remove alpha character",
                  expectedOutput,
-                 PhoneNumberUtil.normalizeDigitsOnly(inputNumber));
+                 PhoneNumberNormalizer.normalizeDigitsOnly(inputNumber));
   }
 
   public void testNormaliseStripNonDiallableCharacters() {


### PR DESCRIPTION
- Refactor the logic to extract the phone context from an RFC3966 URI to a new `PhoneContextParser` class.
- Refactor the number normalization methods `normalizeDigits` and `normalizeDigitsOnly` to a new `PhoneNumberNormalizer` class.
  > This keeps `PhoneNumberUtil.normalizeDigitsOnly` as a shell because it is public.
- Move the constants that are common between `PhoneContextParser` and `PhoneNumberUtil` to a new `Constants` class.

This is a refactor and should not change the logic of the parser. 

Context: b/370922064