### PR TITLE
Replace calls to fprintf with LOG() in unicodetext.cc

### DIFF
--- a/cpp/src/phonenumbers/utf/unicodetext.cc
+++ b/cpp/src/phonenumbers/utf/unicodetext.cc
@@ -371,11 +371,11 @@ void UnicodeText::push_back(char32 c) {
     if (UniLib::IsInterchangeValid(buf, len)) {
       repr_.append(buf, len);
     } else {
-      fprintf(stderr, "Unicode value 0x%x is not valid for interchange\n", c);
+      LOG(WARNING) << "Unicode value 0x" << hex << c << " is not valid for interchange";
       repr_.append(" ", 1);
     }
   } else {
-    fprintf(stderr, "Illegal Unicode value: 0x%x\n", c);
+    LOG(WARNING) << "Illegal Unicode value: 0x" << hex << c;
     repr_.append(" ", 1);
   }
 }

--- a/cpp/src/phonenumbers/utf/unicodetext.cc
+++ b/cpp/src/phonenumbers/utf/unicodetext.cc
@@ -371,14 +371,19 @@ void UnicodeText::push_back(char32 c) {
     if (UniLib::IsInterchangeValid(buf, len)) {
       repr_.append(buf, len);
     } else {
-      LOG(WARNING) << "Unicode value 0x" << hex << c << " is not valid for interchange";
+      std::ostringstream oss;
+      oss << "Unicode value 0x" << std::hex << c << " is not valid for interchange";
+      LOG(WARNING) << oss.str();
       repr_.append(" ", 1);
     }
   } else {
-    LOG(WARNING) << "Illegal Unicode value: 0x" << hex << c;
+    std::ostringstream oss;
+    oss << "Illegal Unicode value: 0x" << std::hex << c;
+    LOG(WARNING) << oss.str();
     repr_.append(" ", 1);
   }
 }
+
 
 int UnicodeText::size() const {
   return CodepointCount(repr_.data_, repr_.size_);


### PR DESCRIPTION
Hi,

This gets rid of the explicit prints to stderr in the unicode push_back operation. It becomes an issue when parsing large amounts of invalid numbers. I ran into this while fuzzing libphonenumber.