### PR TITLE
Revert Gpg plugin changes

### DIFF
--- a/.github/workflows/java-unit-test.yml
+++ b/.github/workflows/java-unit-test.yml
@@ -28,7 +28,7 @@ jobs:
 # it's safe to remove the first line entirely.
     - name: Test Build Tools with Maven
       run: |
-        mvn install -P github-actions -DskipTests=true -Dgpg.skip=true -Dmaven.javadoc.skip=true -B -V
+        mvn install -P github-actions -DskipTests=true  -Dmaven.javadoc.skip=true -B -V
         mvn -P github-actions test
     - name: Test Java API with Ant
       run: |

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -168,28 +168,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>3.1.0</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <gpgArguments>
-            <arg>--batch</arg>
-            <arg>--yes</arg>
-            <arg>--pinentry-mode</arg>
-            <arg>loopback</arg>
-          </gpgArguments>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
         <version>0.8.0</version>
@@ -201,6 +179,36 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>release-sign-artifacts</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+  
   <!-- Until 08. Dec 2016, this pom worked with maven-release-plugin at 2.2.1
        and default SCM dependencies. On 11. Jan, 2017 that was no longer the
        case, presumably because the default SCM version changed (cannot find


### PR DESCRIPTION
By adding GPG plugin outside the profile, we are facing issue with mvn install command. it is giving signin issue.
To avoid that reverting plugin changes.