### PR TITLE
Update Senegal (SN) mobile prefixes: add 71 and 75

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -27537,19 +27537,9 @@
         <exampleNumber>701234567</exampleNumber>
         <nationalNumberPattern>
           7(?:
-            (?:
-              [06-8]\d|
-              [19]0|
-              21
-            )\d|
-            5(?:
-              0[01]|
-              [19]0|
-              2[25]|
-              3[356]|
-              [4-7]\d|
-              8[35]
-            )
+            [0678]\d|        <!-- 70, 76, 77, 78 -->
+            1\d|             <!-- 71 -->
+            5\d{2}           <!-- 75 -->
           )\d{5}
         </nationalNumberPattern>
       </mobile>


### PR DESCRIPTION
### Summary
This PR updates the Senegal (SN) mobile phone numbering plan.

### Changes
- Added support for prefix **71** (new Orange Senegal range).
- Added support for prefix **75** (Promobile, MVNO on Orange network).
- Updated the `<mobile>` national number pattern accordingly.

### Sources
- Orange Senegal official announcement of prefix 71:   https://www.facebook.com/orange.sn/posts/-la-m%C3%AAme-qualit%C3%A9-encore-plus-de-possibilit%C3%A9s-avec-le-71-orange-%C3%A9largit-son-catal/1127210126114441/  

- Promobile Senegal (prefix 75, MVNO using Orange’s network):   https://www.promobile.sn/  

- ARTP Senegal numbering plan:   http://www.artpsenegal.net/index.php?option=com_content&view=article&id=50  

### Notes
These changes ensure libphonenumber correctly validates recently allocated Senegal mobile ranges (71 and 75), which are currently missing from the metadata.