### PR TITLE
Vulnerability: Memory Corruption in libphonenumber AsYouTypeFormatter:AttemptToExtractIdd

### DIFF
--- a/cpp/src/phonenumbers/asyoutypeformatter.cc
+++ b/cpp/src/phonenumbers/asyoutypeformatter.cc
@@ -712,9 +712,9 @@ char AsYouTypeFormatter::NormalizeAndAccrueDigitsAndPlusSign(
     string number;
     UnicodeString(next_char).toUTF8String(number);
     phone_util_.NormalizeDigitsOnly(&number);
-    accrued_input_without_formatting_.append(next_char);
     national_number_.append(number);
     normalized_char = number[0];
+    accrued_input_without_formatting_.append(normalized_char);
   }
   if (remember_position) {
     position_to_remember_ = accrued_input_without_formatting_.length();

--- a/cpp/test/phonenumbers/asyoutypeformatter_test.cc
+++ b/cpp/test/phonenumbers/asyoutypeformatter_test.cc
@@ -916,6 +916,22 @@ TEST_F(AsYouTypeFormatterTest, AYTF_LongIDD_AU) {
   EXPECT_EQ("0011 244 250 253 222", formatter_->InputDigit('2', &result_));
 }
 
+TEST_F(AsYouTypeFormatterTest, AYTF_With_Special_Characters) {
+  formatter_.reset(phone_util_.GetAsYouTypeFormatter(RegionCode::JP()));
+  // +81००23456
+  formatter_->Clear();
+  EXPECT_EQ("+", formatter_->InputDigit('+', &result_));
+  EXPECT_EQ("+8", formatter_->InputDigit('8', &result_));
+  EXPECT_EQ("+81 ", formatter_->InputDigit('1', &result_));
+  EXPECT_EQ("+81 0", formatter_->InputDigit(UnicodeString("\u0966")[0], &result_));
+  EXPECT_EQ("+81 00", formatter_->InputDigit(UnicodeString("\u0966")[0], &result_));
+  EXPECT_EQ("+81००2", formatter_->InputDigit('2', &result_));
+  EXPECT_EQ("+81००23", formatter_->InputDigit('3', &result_));
+  EXPECT_EQ("+81००234", formatter_->InputDigit('4', &result_));
+  EXPECT_EQ("+81००2345", formatter_->InputDigit('5', &result_));
+  EXPECT_EQ("+81००23456", formatter_->InputDigit('6', &result_));
+}
+
 TEST_F(AsYouTypeFormatterTest, AYTF_LongIDD_KR) {
   formatter_.reset(phone_util_.GetAsYouTypeFormatter(RegionCode::KR()));
   // 00300 1 650 253 2250


### PR DESCRIPTION
The memory corruption occurs because the parsing logic fails to pass the normalized character into accrued_input_without_formatting_ when the number starts with special characters during IDD extraction. This results in the tempSubString operation encountering the unnormalized special character's byte sequence, which is misinterpreted as a negative value, leading to a size or index error that causes memory corruption.

To fix the issue, pass the normalized character into accrued_input_without_formatting_.