### PR TITLE
Guard AllNumberGroupsRemainGrouped against indexOf/find(-1) for the country-code skip (Java + C++)

### DIFF
--- a/cpp/src/phonenumbers/phonenumbermatcher.cc
+++ b/cpp/src/phonenumbers/phonenumbermatcher.cc
@@ -123,7 +123,10 @@ bool AllNumberGroupsRemainGrouped(
   if (number.country_code_source() != PhoneNumber::FROM_DEFAULT_COUNTRY) {
     // First skip the country code if the normalized candidate contained it.
     string country_code = SimpleItoa(number.country_code());
-    from_index = normalized_candidate.find(country_code) + country_code.size();
+    size_t country_code_index = normalized_candidate.find(country_code);
+    if (country_code_index != string::npos) {
+      from_index = country_code_index + country_code.size();
+    }
   }
   // Check each group of consecutive digits are not broken into separate
   // groupings in the normalized_candidate string.

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatcher.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatcher.java
@@ -463,7 +463,10 @@ final class PhoneNumberMatcher implements Iterator<PhoneNumberMatch> {
     if (number.getCountryCodeSource() != CountryCodeSource.FROM_DEFAULT_COUNTRY) {
       // First skip the country code if the normalized candidate contained it.
       String countryCode = Integer.toString(number.getCountryCode());
-      fromIndex = normalizedCandidate.indexOf(countryCode) + countryCode.length();
+      int countryCodeIndex = normalizedCandidate.indexOf(countryCode);
+      if (countryCodeIndex >= 0) {
+        fromIndex = countryCodeIndex + countryCode.length();
+      }
     }
     // Check each group of consecutive digits are not broken into separate groupings in the
     // {@code normalizedCandidate} string.

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberMatcherTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberMatcherTest.java
@@ -77,6 +77,21 @@ public class PhoneNumberMatcherTest extends TestMetadataTestCase {
     assertTrue(PhoneNumberMatcher.containsMoreThanOneSlashInNationalNumber(number, candidate));
   }
 
+  public void testAllNumberGroupsRemainGroupedCountryCodeNotInCandidate() throws Exception {
+    // Constructed case: the country code source claims the candidate began with an explicit
+    // country calling code, but the literal digits of that code ("44") do not actually occur in
+    // the candidate text. Previously this desynced fromIndex (indexOf returns -1, and -1 plus the
+    // country code's length was used as a starting position instead of being treated as "not
+    // found"), which made a grouping match that should succeed incorrectly return false.
+    PhoneNumber number = new PhoneNumber();
+    number.setCountryCode(44);
+    number.setCountryCodeSource(CountryCodeSource.FROM_NUMBER_WITH_PLUS_SIGN);
+    StringBuilder candidate = new StringBuilder("020 7031 3000");
+    String[] formattedNumberGroups = {"020", "7031", "3000"};
+    assertTrue(PhoneNumberMatcher.allNumberGroupsRemainGrouped(
+        phoneUtil, number, candidate, formattedNumberGroups));
+  }
+
   /** See {@link PhoneNumberUtilTest#testParseNationalNumber()}. */
   public void testFindNationalNumber() throws Exception {
     // same cases as in testParseNationalNumber


### PR DESCRIPTION
## Issue

https://issuetracker.google.com/issues/552025944

## What's wrong

In `PhoneNumberMatcher.allNumberGroupsRemainGrouped` (Java), when the country calling code isn't a literal substring of the candidate text, `indexOf` returns `-1`, and:

```java
fromIndex = normalizedCandidate.indexOf(countryCode) + countryCode.length();
```

leaves `fromIndex` at a small, wrong, non-negative value instead of "not found." This desyncs the subsequent group-matching loop, which can make a grouping check that should succeed silently return `false` instead — i.e. a valid phone number embedded in free text can fail to match, with no exception. The very next `indexOf` call in the same method (one line below, inside the loop) already guards against exactly this with `if (fromIndex < 0) { return false; }`; this fix applies the same guard to the country-code skip.

In practice this is probably rare, since a matched candidate's text usually does contain the country code's digits somewhere. Confirmed with a constructed case (country code 44, candidate text that doesn't contain "44") added as a new unit test.

## Fix

Guard the `indexOf` result before using it, leaving `fromIndex` at its default (0, i.e. "don't skip anything") when the country code isn't found as a literal substring, rather than propagating a bogus offset.

## Scope across languages

Per the contributing guide's note to check whether a fix applies in C++, Java, and JS:

*   **Java** — fixed (this is the primary fix).
*   **C++** (`cpp/src/phonenumbers/phonenumbermatcher.cc`) — has the exact same pattern with `std::string::find`, and it's arguably worse there: `find` returns `npos` (`size_t` max) on a miss, and the unguarded `+ country_code.size()` wraps around via unsigned overflow into a small, wrong, non-negative `from_index` instead of crashing loudly. Fixed with the same guard.
*   **JS** — not applicable. The JS port has no `PhoneNumberMatcher` (find-numbers-in-text) implementation at all; `allNumberGroupsRemainGrouped`/`AllNumberGroupsRemainGrouped` doesn't exist there. Verified by grepping `javascript/i18n/phonenumbers/` for the function and for any matcher module — only `asyoutypeformatter.js` and `phonenumberutil.js` (parse/format/validate) exist, no text-scanning matcher.

## Testing

No local JDK/C++ toolchain was available to me to run the test suites, so I traced both fixes by hand and I'd appreciate a maintainer/CI double-check.

*   **Java**: `testAllNumberGroupsRemainGroupedCountryCodeNotInCandidate` calls the package-private `allNumberGroupsRemainGrouped` directly with a `PhoneNumber` whose `countryCodeSource` is `FROM_NUMBER_WITH_PLUS_SIGN` (country code 44) and a candidate string that never contains the literal digits "44". Before the fix this returns `false` (bug); after the fix it returns `true`.
*   **C++**: no test added. `AllNumberGroupsRemainGrouped` is in an anonymous namespace in `phonenumbermatcher.cc`, so unlike the Java package-private method it isn't reachable from the test binary in a different translation unit for a direct unit test, and I didn't want to change its linkage just to test this. Happy to take a suggestion from a maintainer on how this is normally exercised (e.g. via `PhoneNumberMatcher::Match`/`Find`) if a regression test is wanted here.
