### PR TITLE
Avoid catastrophic backtracking in the RFC3966 domainname check

### DIFF
--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -328,9 +328,9 @@ public class PhoneNumberUtil {
   // defined in RFC3966.
   private static final String ALPHANUM = VALID_ALPHA + DIGITS;
   private static final String RFC3966_DOMAINLABEL =
-      "[" + ALPHANUM + "]+((\\-)*[" + ALPHANUM + "])*";
+      "[" + ALPHANUM + "]+(\\-+[" + ALPHANUM + "]+)*";
   private static final String RFC3966_TOPLABEL =
-      "[" + VALID_ALPHA + "]+((\\-)*[" + ALPHANUM + "])*";
+      "[" + VALID_ALPHA + "]+(\\-+[" + ALPHANUM + "]+)*";
   private static final String RFC3966_DOMAINNAME =
       "^(" + RFC3966_DOMAINLABEL + "\\.)*" + RFC3966_TOPLABEL + "\\.?$";
   static final Pattern RFC3966_DOMAINNAME_PATTERN = Pattern.compile(RFC3966_DOMAINNAME);

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
@@ -31,6 +31,7 @@ import com.google.i18n.phonenumbers.metadata.source.MetadataSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.junit.Assert;
 import org.junit.function.ThrowingRunnable;
 import org.mockito.Mockito;
@@ -2219,6 +2220,41 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
                    NumberParseException.ErrorType.TOO_LONG,
                    e.getErrorType());
     }
+  }
+
+  public void testParseRFC3966PhoneContextDomainname() throws Exception {
+    // Domain phone-contexts keep parsing, including labels with single or repeated hyphens.
+    assertEquals(US_LOCAL_NUMBER,
+        phoneUtil.parse("tel:253-0000;phone-context=www.google.com", RegionCode.US));
+    assertEquals(US_LOCAL_NUMBER,
+        phoneUtil.parse("tel:253-0000;phone-context=ex--ample.domain.com", RegionCode.US));
+
+    // A long ambiguous domain is rejected. The old label pattern ([alnum]+((\-)*[alnum])*) made
+    // backtracking engines in the JS and Python ports of this pattern spend minutes on this
+    // input; Java's own matcher prunes it, this pins the rejection and the accepted language.
+    StringBuilder evilContext = new StringBuilder(100);
+    for (int i = 0; i < 25; i++) {
+      evilContext.append("aa.");
+    }
+    evilContext.append("aa!");
+    try {
+      phoneUtil.parse("tel:253-0000;phone-context=" + evilContext, RegionCode.US);
+      fail("This should not parse without throwing an exception.");
+    } catch (NumberParseException e) {
+      // Expected this exception.
+    }
+
+    // The rewritten label matches alnum runs separated by one or more hyphens, but not labels
+    // with leading/trailing hyphens or empty labels.
+    Pattern domainname = PhoneNumberUtil.RFC3966_DOMAINNAME_PATTERN;
+    assertTrue(domainname.matcher("a.b.c").matches());
+    assertTrue(domainname.matcher("ab-cd.ef").matches());
+    assertTrue(domainname.matcher("a--b.c").matches());
+    assertTrue(domainname.matcher("example.com.").matches());
+    assertFalse(domainname.matcher("aa.bb-").matches());
+    assertFalse(domainname.matcher("aa..bb").matches());
+    assertFalse(domainname.matcher("-aa.bb").matches());
+    assertFalse(domainname.matcher("a-.b").matches());
   }
 
   public void testParseWithInternationalPrefixes() throws Exception {

--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -784,8 +784,8 @@ i18n.phonenumbers.PhoneNumberUtil.ALPHANUM_ =
  * @private
  */
 i18n.phonenumbers.PhoneNumberUtil.RFC3966_DOMAINLABEL_ = '['
-    + i18n.phonenumbers.PhoneNumberUtil.ALPHANUM_ + ']+((\\-)*['
-    + i18n.phonenumbers.PhoneNumberUtil.ALPHANUM_ + '])*';
+    + i18n.phonenumbers.PhoneNumberUtil.ALPHANUM_ + ']+(\\-+['
+    + i18n.phonenumbers.PhoneNumberUtil.ALPHANUM_ + ']+)*';
 
 /**
  * @const
@@ -793,8 +793,8 @@ i18n.phonenumbers.PhoneNumberUtil.RFC3966_DOMAINLABEL_ = '['
  * @private
  */
 i18n.phonenumbers.PhoneNumberUtil.RFC3966_TOPLABEL_ = '['
-    + i18n.phonenumbers.PhoneNumberUtil.VALID_ALPHA_ + ']+((\\-)*['
-    + i18n.phonenumbers.PhoneNumberUtil.ALPHANUM_ + '])*';
+    + i18n.phonenumbers.PhoneNumberUtil.VALID_ALPHA_ + ']+(\\-+['
+    + i18n.phonenumbers.PhoneNumberUtil.ALPHANUM_ + ']+)*';
 
 /**
  * @const


### PR DESCRIPTION
The per-label pattern used to validate the `phone-context` domain during parsing is ambiguous:

```
alnum+((\\-)*[alnum])*
```

An alphanumeric run can be split between the leading `+` and the repeating group in many equivalent ways, so when the overall match fails, a backtracking engine re-explores the suffix once per split — exponential in the number of labels.

Java's own matcher prunes this shape quickly (~1 ms on a 123-char failing input on JDK 26), so the JVM library isn't practically affected. However:

- the **JS port** mirrors this pattern and hangs for over **2 minutes** on a 93-char failing `phone-context` (V8),
- the **Python port** (daviddrysdale/python-phonenumbers) mirrors it too and takes **~50 s** on 98 chars through its public `parse()` (CPython 3.10, phonenumbers 9.0.37).

Repro for the JS shape:

```js
const DOMAINNAME = /^([a-zA-Z0-9]+((\\-)*[a-zA-Z0-9])*\\.)*[a-zA-Z]+((\\-)*[a-zA-Z0-9])*\\.?$/;
const t = Date.now();
DOMAINNAME.test("aa.".repeat(30) + "aa!");
console.log(Date.now() - t);   // ~147000 ms
```

This rewrites the label as `alnum+(\\-+[alnum]+)*` — same accepted language (alnum runs separated by one or more hyphens, still no leading/trailing hyphen or empty labels), but each position matches exactly one way. With the rewrite the repro above is 0 ms.

Changes `PhoneNumberUtil.java` and the hand-maintained JS mirror in `phonenumberutil.js`, and adds tests pinning the accepted language (single and repeated hyphens accepted; leading/trailing hyphens and empty labels rejected) plus rejection of the long ambiguous phone-context. Full `mvn -pl java/libphonenumber test` suite passes locally (285 tests, 0 failures).

Same fix proposed in daviddrysdale/python-phonenumbers#324.

This was reported to Google's security team, who assessed it as below the bar for security tracking and suggested public disclosure.